### PR TITLE
Disable restart testing

### DIFF
--- a/.github/workflows/test-microk8s.yaml
+++ b/.github/workflows/test-microk8s.yaml
@@ -47,11 +47,12 @@ jobs:
       run: |
         set -eux
         sg microk8s -c './tests/run.sh -m edge'
-        sudo snap restart microk8s
-        sg microk8s -c 'microk8s.status --wait-ready'
-        juju wait -wv
-        kubectl wait -nkubeflow --for=condition=available deployment --all --timeout=5m
-        sg microk8s -c './tests/run.sh -m edge'
+        # Disabled until we can switch to https://github.com/canonical/argo-operators
+        # sudo snap restart microk8s
+        # sg microk8s -c 'microk8s.status --wait-ready'
+        # juju wait -wv
+        # kubectl wait -nkubeflow --for=condition=available deployment --all --timeout=5m
+        # sg microk8s -c './tests/run.sh -m edge'
 
     - name: Juju status
       run: juju status


### PR DESCRIPTION
Will be fixed by https://github.com/canonical/minio-operator/pull/9, but that's blocked by switching over to the new argo-operators repo:

https://github.com/canonical/argo-operators