### PR TITLE
Better handling of pod logs in CI

### DIFF
--- a/.github/workflows/test-microk8s.yaml
+++ b/.github/workflows/test-microk8s.yaml
@@ -233,7 +233,7 @@ jobs:
         set -eux
         juju ssh ubuntu/0 <<EOF
           set -eux
-          tar -czvf selenium.tar.gz /tmp/selenium-*.png
+          tar -czvf selenium.tar.gz /tmp/selenium-*.png || true
         EOF
         juju scp ubuntu/0:selenium.tar.gz selenium-${{ strategy.job-index }}.tar.gz
       if: failure()
@@ -303,7 +303,7 @@ jobs:
           for namespace in admin kubeflow; do
               for pod in \$(microk8s kubectl get pods -n \$namespace -o custom-columns=:metadata.name --no-headers); do
                   for container in \$(microk8s kubectl get pods -n \$namespace -o jsonpath="{.spec.containers[*].name}" \$pod); do
-                    microk8s kubectl logs -n \$namespace --timestamps \$pod -c \$container > stdout-${{ strategy.job-index }}/\$namespace-\$pod-\$container.log
+                    microk8s kubectl logs -n \$namespace --timestamps \$pod -c \$container > stdout-${{ strategy.job-index }}/\$namespace-\$pod-\$container.log || true
                   done
               done
           done


### PR DESCRIPTION
We don't want to fail the entire pod log schlepping if a single pod fails due to still being initializing.