### PR TITLE
README.md: updates broken link to nonexistent file

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Where `<NAMESPACE>` matches the name of the Juju model that you're using,
 and `path/to/job/definition.yaml` should point to a `TFJob` definition
 similar to the `mnist.yaml` example [found here][mnist-example].
 
-[mnist-example]: charms/tf-job-operator/files/mnist.yaml
+[mnist-example]: https://github.com/canonical/tfjob-operator/blob/master/examples/mnist.yaml
 
 ### TensorFlow Serving
 


### PR DESCRIPTION
Link to mnist example is broken as the file it points to has been removed. I think updating the link to point to this [example](https://github.com/canonical/tfjob-operator/blob/master/examples/mnist.yaml) is a good option as it is the 'hello world' equivalent of a TFJob.

Fixes #372 