### PR TITLE
fix: Resolve notebook page forbidden (#381)

### DIFF
--- a/bundle-lite.yaml
+++ b/bundle-lite.yaml
@@ -6,7 +6,7 @@ applications:
   istio-ingressgateway:      { charm: cs:istio-ingressgateway-20,     scale: 1 }
   istio-pilot:               { charm: cs:istio-pilot-20,              scale: 1, options: { default-gateway: "kubeflow-gateway" }  }
   jupyter-controller:        { charm: cs:jupyter-controller-55,       scale: 1 }
-  jupyter-ui:                { charm: cs:jupyter-ui-9,                scale: 1 }
+  jupyter-ui:                { charm: cs:jupyter-ui-10,               scale: 1 }
   kfp-api:                   { charm: cs:kfp-api-12,                  scale: 1 }
   kfp-db:                    { charm: cs:~charmed-osm/mariadb-k8s-35, scale: 1, options: { database: mlpipeline } }
   kfp-persistence:           { charm: cs:kfp-persistence-9,           scale: 1 }

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -6,7 +6,7 @@ applications:
   istio-ingressgateway:      { charm: cs:istio-ingressgateway-20,     scale: 1 }
   istio-pilot:               { charm: cs:istio-pilot-20,              scale: 1, options: { default-gateway: "kubeflow-gateway" } }
   jupyter-controller:        { charm: cs:jupyter-controller-55,       scale: 1 }
-  jupyter-ui:                { charm: cs:jupyter-ui-9,                scale: 1 }
+  jupyter-ui:                { charm: cs:jupyter-ui-10,               scale: 1 }
   katib-controller:          { charm: cs:katib-controller-30,         scale: 1 }
   katib-db:                  { charm: cs:~charmed-osm/mariadb-k8s-35, scale: 1, options: { database: katib } }
   katib-db-manager:          { charm: cs:katib-db-manager-4,          scale: 1 }


### PR DESCRIPTION
Bumps the `jupyter-ui` charm to revision 10 to resolve an error with the notebook server page (`/jupyter`) which gives a 403:forbidden error when browsing in the dashboard.

Fixes #381 