### PR TITLE
Enables training-operator for all bundles

### DIFF
--- a/bundle-edge.yaml
+++ b/bundle-edge.yaml
@@ -6,9 +6,8 @@ applications:
   kfp-db:                    { charm: cs:~charmed-osm/mariadb-k8s-35, scale: 1, options: { database: mlpipeline } }
   kfp-persistence:           { charm: cs:kfp-persistence-9,           scale: 1 }
   kfp-schedwf:               { charm: cs:kfp-schedwf-9,               scale: 1 }
-  pytorch-operator:          { charm: cs:pytorch-operator-53,         scale: 1 }
   seldon-controller-manager: { charm: cs:seldon-core-50,              scale: 1 }
-  tfjob-operator:            { charm: cs:tfjob-operator-1,            scale: 1 }
+  training-operator:          { charm: cs:training-operator-1,         scale: 1 }
 relations:
 - [argo-controller, minio]
 - [kfp-api, kfp-db]

--- a/bundle-lite.yaml
+++ b/bundle-lite.yaml
@@ -20,9 +20,8 @@ applications:
   minio:                     { charm: cs:minio-55,                    scale: 1 }
   mlmd:                      { charm: cs:mlmd-5,                      scale: 1 }
   oidc-gatekeeper:           { charm: cs:oidc-gatekeeper-54,          scale: 1 }
-  pytorch-operator:          { charm: cs:pytorch-operator-53,         scale: 1 }
   seldon-controller-manager: { charm: cs:seldon-core-50,              scale: 1 }
-  tfjob-operator:            { charm: cs:tfjob-operator-1,            scale: 1 }
+  training-operator:          { charm: cs:training-operator-1,         scale: 1 }
 relations:
 - [argo-controller, minio]
 - [dex-auth:oidc-client, oidc-gatekeeper:oidc-client]

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -24,10 +24,9 @@ applications:
   mlmd:                      { charm: cs:mlmd-5,                      scale: 1 }
   minio:                     { charm: cs:minio-55,                    scale: 1 }
   oidc-gatekeeper:           { charm: cs:oidc-gatekeeper-54,          scale: 1 }
-  pytorch-operator:          { charm: cs:pytorch-operator-53,         scale: 1 }
   spark:                     { charm: cs:~spark-charmers/spark-2,     scale: 1 }
   seldon-controller-manager: { charm: cs:seldon-core-50,              scale: 1 }
-  tfjob-operator:            { charm: cs:tfjob-operator-1,            scale: 1 }
+  training-operator:          { charm: cs:training-operator-1,         scale: 1 }
 relations:
 - [argo-controller, minio]
 - [dex-auth:oidc-client, oidc-gatekeeper:oidc-client]

--- a/tests/test_kubectl.py
+++ b/tests/test_kubectl.py
@@ -59,10 +59,9 @@ def test_running_full():
         'minio': 'Running',
         'mlmd': 'Running',
         'oidc-gatekeeper': 'Running',
-        'pytorch-operator': 'Running',
         'seldon-controller-manager': 'Running',
         'spark': 'Running',
-        'tfjob-operator': 'Running',
+        'training-operator': 'Running',
     }
 
 
@@ -90,9 +89,8 @@ def test_running_lite():
         'kfp-ui': 'Running',
         'kfp-viewer': 'Running',
         'kfp-viz': 'Running',
-        'pytorch-operator': 'Running',
         'seldon-controller-manager': 'Running',
-        'tfjob-operator': 'Running',
+        'training-operator': 'Running',
     }
 
 
@@ -106,9 +104,8 @@ def test_running_edge():
         'kfp-persistence': 'Running',
         'kfp-schedwf': 'Running',
         'minio': 'Running',
-        'pytorch-operator': 'Running',
         'seldon-controller-manager': 'Running',
-        'tfjob-operator': 'Running',
+        'training-operator': 'Running',
     }
 
 
@@ -123,16 +120,18 @@ def test_crd_created_full():
             'notebooks.kubeflow.org',
             'poddefaults.kubeflow.org',
             'profiles.kubeflow.org',
-            'pytorchjobs.kubeflow.org',
             'scheduledworkflows.kubeflow.org',
             'seldondeployments.machinelearning.seldon.io',
             'servicerolebindings.rbac.istio.io',
             'serviceroles.rbac.istio.io',
             'suggestions.kubeflow.org',
-            'tfjobs.kubeflow.org',
             'trials.kubeflow.org',
             'viewers.kubeflow.org',
             'workflows.argoproj.io',
+            'xgboostjobs.kubeflow.org',
+            'mxjobs.kubeflow.org',
+            'pytorchjobs.kubeflow.org',
+            'tfjobs.kubeflow.org',
         }
     )
 
@@ -147,14 +146,16 @@ def test_crd_created_lite():
             'notebooks.kubeflow.org',
             'poddefaults.kubeflow.org',
             'profiles.kubeflow.org',
-            'pytorchjobs.kubeflow.org',
             'scheduledworkflows.kubeflow.org',
             'seldondeployments.machinelearning.seldon.io',
             'servicerolebindings.rbac.istio.io',
             'serviceroles.rbac.istio.io',
-            'tfjobs.kubeflow.org',
             'viewers.kubeflow.org',
             'workflows.argoproj.io',
+            'xgboostjobs.kubeflow.org',
+            'mxjobs.kubeflow.org',
+            'pytorchjobs.kubeflow.org',
+            'tfjobs.kubeflow.org',
         }
     )
 
@@ -166,11 +167,13 @@ def test_crd_created_edge():
     names = {i['metadata']['name'] for i in crds['items']}
     assert names.issuperset(
         {
-            'pytorchjobs.kubeflow.org',
             'scheduledworkflows.kubeflow.org',
             'seldondeployments.machinelearning.seldon.io',
-            'tfjobs.kubeflow.org',
             'workflows.argoproj.io',
+            'xgboostjobs.kubeflow.org',
+            'mxjobs.kubeflow.org',
+            'pytorchjobs.kubeflow.org',
+            'tfjobs.kubeflow.org',
         }
     )
 
@@ -226,14 +229,11 @@ def test_service_accounts_created_full():
             'mlmd-operator',
             'oidc-gatekeeper-operator',
             'pipeline-runner',
-            'pytorch-operator',
-            'pytorch-operator-operator',
             'seldon-controller-manager',
             'seldon-controller-manager-operator',
             'spark',
             'spark-operator',
-            'tfjob-operator',
-            'tfjob-operator-operator',
+            'training-operator',
         },
     )
 
@@ -282,12 +282,9 @@ def test_service_accounts_created_lite():
             'mlmd-operator',
             'oidc-gatekeeper-operator',
             'pipeline-runner',
-            'pytorch-operator',
-            'pytorch-operator-operator',
             'seldon-controller-manager',
             'seldon-controller-manager-operator',
-            'tfjob-operator',
-            'tfjob-operator-operator',
+            'training-operator',
         },
     )
 
@@ -311,11 +308,8 @@ def test_service_accounts_created_edge():
             'kfp-schedwf-operator',
             'minio-operator',
             'pipeline-runner',
-            'pytorch-operator',
-            'pytorch-operator-operator',
             'seldon-controller-manager',
             'seldon-controller-manager-operator',
-            'tfjob-operator',
-            'tfjob-operator-operator',
+            'training-operator',
         },
     )


### PR DESCRIPTION
These commits add the training-operator, which replaces pytorch and tfjob operators, and enables checks for testing it.