### PR TITLE
Enables Charmhub publish job

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -15,30 +15,24 @@ jobs:
     - run: sudo apt update && sudo apt install tox
     - run: tox -e lint
 
-  actions:
-    name: Github Actions
+  integration-tests:
+    name: Integration tests on Github
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        juju: [2.9/stable]
-        microk8s: [1.20/stable]
     steps:
     - name: Check out code
       uses: actions/checkout@v2
 
-    - uses: balchua/microk8s-actions@v0.2.2
+    - name: Setup operator environment
+      uses: charmed-kubernetes/actions-operator@main
       with:
-        channel: '${{ matrix.microk8s }}'
-        addons: '["dns", "storage", "rbac"]'
+        provider: microk8s
+        channel: 1.21/stable
+        charmcraft-channel: latest/candidate
 
     - name: Install test dependencies
       run: |
         set -eux
-        for snap in charmcraft charm juju-helpers juju-wait; do
-            sudo snap install $snap --classic
-        done
-        sudo snap install juju --classic --channel ${{ matrix.juju }}
+        sudo snap install juju-wait --classic
         sudo apt update
         sudo apt install -y libssl-dev python3-pip
         sudo pip3 install -r requirements.txt
@@ -172,7 +166,7 @@ jobs:
       fail-fast: false
       matrix:
         juju: [2.9/stable]
-        microk8s: [1.20/stable]
+        microk8s: [1.21/stable]
         bundle: [lite, full]
     steps:
     - name: Check out code
@@ -205,9 +199,10 @@ jobs:
       run: |
         juju ssh ubuntu/0 <<EOF
           set -eux
-          for snap in charmcraft charm juju-helpers juju-wait; do
+          for snap in juju-helpers juju-wait; do
               sudo snap install \$snap --classic
           done
+          sudo snap install charmcraft --classic --channel=latest/candidate
           sudo snap install juju --classic --channel ${{ matrix.juju }}
           sudo snap install microk8s --classic --channel ${{ matrix.microk8s }}
           sudo apt update

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,36 +1,34 @@
 name: Publish
-
 on:
   push:
     branches:
       - master
-    paths:
-      - charms/**
-      - bundle*.yaml
+      - main
+      - track/**
+  pull_request:
+    branches:
+      - master
+      - main
+      - track/**
 
 jobs:
-  all-bundles:
-    name: All Bundles
+  publish-bundle:
+    name: Publish bundle-kubeflow
     runs-on: ubuntu-latest
-
+    env:
+      CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
     steps:
-    - name: Check out code
-      uses: actions/checkout@v2
+      #FIXME: this will only publish the kubeflow bundle, no edge/lite
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: sudo snap install charmcraft --classic --channel=latest/edge
+      - name: Pack and publish bundle
+        run: |
+          set -ex
+          charmcraft pack --destructive-mode
+          charmcraft upload ./*.zip
+          export REVISION=$(charmcraft revisions kubeflow 2>&1 | awk 'NR==2 {print $1}')
+          charmcraft release kubeflow --revision $REVISION --channel=latest/edge
 
-    - name: Install dependencies
-      run: |
-        set -eux
-        sudo snap install charm --classic
-        sudo snap install juju-bundle --classic
 
-    - name: Publish bundle
-      env:
-        CHARMSTORE_CREDENTIAL: ${{ secrets.CHARMSTORE_CREDENTIAL }}
-      run: |
-        set -eux
-        echo $CHARMSTORE_CREDENTIAL > ~/.go-cookies
-        git clone git://git.launchpad.net/canonical-osm
-        cp -r canonical-osm/charms/interfaces/juju-relation-mysql mysql
-        juju-bundle publish -b bundle.yaml --url cs:~kubeflow-charmers/kubeflow
-        juju-bundle publish -b bundle-lite.yaml --url cs:~kubeflow-charmers/kubeflow-lite
-        juju-bundle publish -b bundle-edge.yaml --url cs:~kubeflow-charmers/kubeflow-edge
+

--- a/bundle-edge.yaml
+++ b/bundle-edge.yaml
@@ -1,14 +1,14 @@
 bundle: kubernetes
+name: kubeflow-edge
 applications:
-  argo-controller:           { charm: cs:argo-controller-51,          scale: 1 }
-  minio:                     { charm: cs:minio-55,                    scale: 1 }
-  kfp-api:                   { charm: cs:kfp-api-12,                  scale: 1 }
-  kfp-db:                    { charm: cs:~charmed-osm/mariadb-k8s-35, scale: 1, options: { database: mlpipeline } }
-  kfp-persistence:           { charm: cs:kfp-persistence-9,           scale: 1 }
-  kfp-schedwf:               { charm: cs:kfp-schedwf-9,               scale: 1 }
-  pytorch-operator:          { charm: cs:pytorch-operator-53,         scale: 1 }
-  seldon-controller-manager: { charm: cs:seldon-core-50,              scale: 1 }
-  tfjob-operator:            { charm: cs:tfjob-operator-1,            scale: 1 }
+  argo-controller:           { charm: argo-controller,         channel: latest/edge, scale: 1 }
+  minio:                     { charm: minio,                   channel: latest/edge, scale: 1 }
+  kfp-api:                   { charm: kfp-api,                 channel: latest/edge, scale: 1 }
+  kfp-db:                    { charm: charmed-osm-mariadb-k8s, channel: latest/edge, scale: 1, options: { database: mlpipeline } }
+  kfp-persistence:           { charm: kfp-persistence,         channel: latest/edge, scale: 1 }
+  kfp-schedwf:               { charm: kfp-schedwf,             channel: latest/edge, scale: 1 }
+  seldon-controller-manager: { charm: seldon-core,             channel: latest/edge, scale: 1 }
+  training-operator:         { charm: training-operator,       channel: latest/edge, scale: 1, trust: true }
 relations:
 - [argo-controller, minio]
 - [kfp-api, kfp-db]

--- a/bundle-lite.yaml
+++ b/bundle-lite.yaml
@@ -1,28 +1,29 @@
 bundle: kubernetes
+name: kubeflow-lite
 applications:
-  admission-webhook:         { charm: cs:admission-webhook-10,        scale: 1 }
-  argo-controller:           { charm: cs:argo-controller-51,          scale: 1 }
-  dex-auth:                  { charm: cs:dex-auth-60,                 scale: 1 }
-  istio-ingressgateway:      { charm: cs:istio-ingressgateway-20,     scale: 1 }
-  istio-pilot:               { charm: cs:istio-pilot-20,              scale: 1, options: { default-gateway: "kubeflow-gateway" }  }
-  jupyter-controller:        { charm: cs:jupyter-controller-56,       scale: 1 }
-  jupyter-ui:                { charm: cs:jupyter-ui-10,               scale: 1 }
-  kfp-api:                   { charm: cs:kfp-api-12,                  scale: 1 }
-  kfp-db:                    { charm: cs:~charmed-osm/mariadb-k8s-35, scale: 1, options: { database: mlpipeline } }
-  kfp-persistence:           { charm: cs:kfp-persistence-9,           scale: 1 }
-  kfp-schedwf:               { charm: cs:kfp-schedwf-9,               scale: 1 }
-  kfp-ui:                    { charm: cs:kfp-ui-12,                   scale: 1 }
-  kfp-viewer:                { charm: cs:kfp-viewer-9,                scale: 1 }
-  kfp-viz:                   { charm: cs:kfp-viz-8,                   scale: 1 }
-  kubeflow-dashboard:        { charm: cs:kubeflow-dashboard-56,       scale: 1 }
-  kubeflow-profiles:         { charm: cs:kubeflow-profiles-52,        scale: 1 }
-  kubeflow-volumes:          { charm: cs:kubeflow-volumes-0,          scale: 1 }
-  minio:                     { charm: cs:minio-55,                    scale: 1 }
-  mlmd:                      { charm: cs:mlmd-5,                      scale: 1 }
-  oidc-gatekeeper:           { charm: cs:oidc-gatekeeper-54,          scale: 1 }
-  pytorch-operator:          { charm: cs:pytorch-operator-53,         scale: 1 }
-  seldon-controller-manager: { charm: cs:seldon-core-50,              scale: 1 }
-  tfjob-operator:            { charm: cs:tfjob-operator-1,            scale: 1 }
+  admission-webhook:             { charm: admission-webhook,       channel: latest/edge, scale: 1 }
+  argo-controller:               { charm: argo-controller,         channel: latest/edge, scale: 1 }
+  dex-auth:                      { charm: dex-auth,                channel: latest/edge, scale: 1, trust: true }
+  istio-ingressgateway-operator: { charm: istio-gateway,           channel: latest/edge, scale: 1, trust: true, options: { kind: ingress } }
+  istio-pilot:                   { charm: istio-pilot,             channel: latest/edge, scale: 1, options: { default-gateways: "kubeflow-gateway" } }
+  jupyter-controller:            { charm: jupyter-controller,      channel: latest/edge, scale: 1 }
+  jupyter-ui:                    { charm: jupyter-ui,              channel: latest/edge, scale: 1 }
+  kfp-api:                       { charm: kfp-api,                 channel: latest/edge, scale: 1 }
+  kfp-db:                        { charm: charmed-osm-mariadb-k8s, channel: latest/edge, scale: 1, options: { database: mlpipeline } }
+  kfp-persistence:               { charm: kfp-persistence,         channel: latest/edge, scale: 1 }
+  kfp-schedwf:                   { charm: kfp-schedwf,             channel: latest/edge, scale: 1 }
+  kfp-ui:                        { charm: kfp-ui,                  channel: latest/edge, scale: 1 }
+  kfp-viewer:                    { charm: kfp-viewer,              channel: latest/edge, scale: 1 }
+  kfp-viz:                       { charm: kfp-viz,                 channel: latest/edge, scale: 1 }
+  kubeflow-dashboard:            { charm: kubeflow-dashboard,      channel: latest/edge, scale: 1 }
+  kubeflow-profiles:             { charm: kubeflow-profiles,       channel: latest/edge, scale: 1 }
+  kubeflow-volumes:              { charm: kubeflow-volumes,        channel: latest/edge, scale: 1 }
+  mlmd:                          { charm: mlmd,                    channel: latest/edge, scale: 1 }
+  minio:                         { charm: minio,                   channel: latest/edge, scale: 1 }
+  oidc-gatekeeper:               { charm: oidc-gatekeeper,         channel: latest/edge, scale: 1 }
+  spark:                         { charm: cs:~spark-charmers/spark-2,     scale: 1 }
+  seldon-controller-manager:     { charm: seldon-core,             channel: latest/edge, scale: 1 }
+  training-operator:             { charm: training-operator,       channel: latest/edge, scale: 1, trust: true }
 relations:
 - [argo-controller, minio]
 - [dex-auth:oidc-client, oidc-gatekeeper:oidc-client]
@@ -31,9 +32,9 @@ relations:
 - [istio-pilot:ingress, kfp-ui:ingress]
 - [istio-pilot:ingress, kubeflow-dashboard:ingress]
 - [istio-pilot:ingress, kubeflow-volumes:ingress]
-- [istio-pilot:istio-pilot, istio-ingressgateway:istio-pilot]
 - [istio-pilot:ingress, oidc-gatekeeper:ingress]
 - [istio-pilot:ingress-auth, oidc-gatekeeper:ingress-auth]
+- [istio-pilot:istio-pilot, istio-ingressgateway-operator:istio-pilot]
 - [kfp-api, kfp-db]
 - [kfp-api:kfp-api, kfp-persistence:kfp-api]
 - [kfp-api:kfp-api, kfp-ui:kfp-api]
@@ -41,3 +42,4 @@ relations:
 - [kfp-api:object-storage, minio:object-storage]
 - [kfp-ui:object-storage, minio:object-storage]
 - [kubeflow-profiles, kubeflow-dashboard]
+- [mlmd:grpc, envoy:grpc]

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -1,33 +1,40 @@
 bundle: kubernetes
+name: kubeflow
 applications:
-  admission-webhook:         { charm: cs:admission-webhook-10,        scale: 1 }
-  argo-controller:           { charm: cs:argo-controller-51,          scale: 1 }
-  dex-auth:                  { charm: cs:dex-auth-60,                 scale: 1 }
-  istio-ingressgateway:      { charm: cs:istio-ingressgateway-20,     scale: 1 }
-  istio-pilot:               { charm: cs:istio-pilot-20,              scale: 1, options: { default-gateway: "kubeflow-gateway" } }
-  jupyter-controller:        { charm: cs:jupyter-controller-56,       scale: 1 }
-  jupyter-ui:                { charm: cs:jupyter-ui-10,               scale: 1 }
-  katib-controller:          { charm: cs:katib-controller-30,         scale: 1 }
-  katib-db:                  { charm: cs:~charmed-osm/mariadb-k8s-35, scale: 1, options: { database: katib } }
-  katib-db-manager:          { charm: cs:katib-db-manager-4,          scale: 1 }
-  katib-ui:                  { charm: cs:katib-ui-30,                 scale: 1 }
-  kfp-api:                   { charm: cs:kfp-api-12,                  scale: 1 }
-  kfp-db:                    { charm: cs:~charmed-osm/mariadb-k8s-35, scale: 1, options: { database: mlpipeline } }
-  kfp-persistence:           { charm: cs:kfp-persistence-9,           scale: 1 }
-  kfp-schedwf:               { charm: cs:kfp-schedwf-9,               scale: 1 }
-  kfp-ui:                    { charm: cs:kfp-ui-12,                   scale: 1 }
-  kfp-viewer:                { charm: cs:kfp-viewer-9,                scale: 1 }
-  kfp-viz:                   { charm: cs:kfp-viz-8,                   scale: 1 }
-  kubeflow-dashboard:        { charm: cs:kubeflow-dashboard-56,       scale: 1 }
-  kubeflow-profiles:         { charm: cs:kubeflow-profiles-52,        scale: 1 }
-  kubeflow-volumes:          { charm: cs:kubeflow-volumes-0,          scale: 1 }
-  mlmd:                      { charm: cs:mlmd-5,                      scale: 1 }
-  minio:                     { charm: cs:minio-55,                    scale: 1 }
-  oidc-gatekeeper:           { charm: cs:oidc-gatekeeper-54,          scale: 1 }
-  pytorch-operator:          { charm: cs:pytorch-operator-53,         scale: 1 }
-  spark:                     { charm: cs:~spark-charmers/spark-2,     scale: 1 }
-  seldon-controller-manager: { charm: cs:seldon-core-50,              scale: 1 }
-  tfjob-operator:            { charm: cs:tfjob-operator-1,            scale: 1 }
+  admission-webhook:             { charm: admission-webhook,       channel: latest/edge, scale: 1 }
+  argo-controller:               { charm: argo-controller,         channel: latest/edge, scale: 1 }
+  argo-server:                   { charm: argo-server,             channel: latest/edge, scale: 1 }
+  dex-auth:                      { charm: dex-auth,                channel: latest/edge, scale: 1, trust: true }
+  envoy:                         { charm: envoy,                   channel: latest/edge, scale: 1 }
+  istio-ingressgateway-operator: { charm: istio-gateway,           channel: latest/edge, scale: 1, trust: true, options: { kind: ingress } }
+  istio-pilot:                   { charm: istio-pilot,             channel: latest/edge, scale: 1, trust: true, options: { default-gateways: "kubeflow-gateway" } }
+  jupyter-controller:            { charm: jupyter-controller,      channel: latest/edge, scale: 1 }
+  jupyter-ui:                    { charm: jupyter-ui,              channel: latest/edge, scale: 1 }
+  katib-controller:              { charm: katib-controller,        channel: latest/edge, scale: 1 }
+  katib-db:                      { charm: charmed-osm-mariadb-k8s, channel: latest/edge, scale: 1, options: { database: katib } }
+  katib-db-manager:              { charm: katib-db-manager,        channel: latest/edge, scale: 1 }
+  katib-ui:                      { charm: katib-ui,                channel: latest/edge, scale: 1 }
+  kfp-api:                       { charm: kfp-api,                 channel: latest/edge, scale: 1 }
+  kfp-db:                        { charm: charmed-osm-mariadb-k8s, channel: latest/edge, scale: 1, options: { database: mlpipeline } }
+  kfp-persistence:               { charm: kfp-persistence,         channel: latest/edge, scale: 1 }
+  kfp-profile-controller:        { charm: kfp-profile-controller,  channel: latest/edge, scale: 1 }
+  kfp-schedwf:                   { charm: kfp-schedwf,             channel: latest/edge, scale: 1 }
+  kfp-ui:                        { charm: kfp-ui,                  channel: latest/edge, scale: 1 }
+  kfp-viewer:                    { charm: kfp-viewer,              channel: latest/edge, scale: 1 }
+  kfp-viz:                       { charm: kfp-viz,                 channel: latest/edge, scale: 1 }
+  kubeflow-dashboard:            { charm: kubeflow-dashboard,      channel: latest/edge, scale: 1 }
+  kubeflow-profiles:             { charm: kubeflow-profiles,       channel: latest/edge, scale: 1 }
+  kubeflow-volumes:              { charm: kubeflow-volumes,        channel: latest/edge, scale: 1 }
+  metacontroller-operator:       { charm: metacontroller-operator, channel: latest/edge, scale: 1, trust: true }
+  mlmd:                          { charm: mlmd,                    channel: latest/edge, scale: 1 }
+  minio:                         { charm: minio,                   channel: latest/edge, scale: 1 }
+  oidc-gatekeeper:               { charm: oidc-gatekeeper,         channel: latest/edge, scale: 1 }
+  seldon-controller-manager:     { charm: seldon-core,             channel: latest/edge, scale: 1 }
+  spark:                         { charm: cs:~spark-charmers/spark-2,     scale: 1 }
+  tensorboard-controller:        { charm: tensorboard-controller,  channel: latest/edge, scale: 1 }
+  tensorboards-web-app:          { charm: tensorboards-web-app,    channel: latest/edge, scale: 1 }
+  training-operator:             { charm: training-operator,       channel: latest/edge, scale: 1, trust: true }
+  kubeflow-roles:                { charm: kubeflow-roles,          channel: latest/edge, scale: 1, trust: true }
 relations:
 - [argo-controller, minio]
 - [dex-auth:oidc-client, oidc-gatekeeper:oidc-client]
@@ -39,12 +46,15 @@ relations:
 - [istio-pilot:ingress, kubeflow-volumes:ingress]
 - [istio-pilot:ingress, oidc-gatekeeper:ingress]
 - [istio-pilot:ingress-auth, oidc-gatekeeper:ingress-auth]
-- [istio-pilot:istio-pilot, istio-ingressgateway:istio-pilot]
+- [istio-pilot:istio-pilot, istio-ingressgateway-operator:istio-pilot]
+- [istio-pilot:ingress, tensorboards-web-app:ingress]
 - [katib-db-manager, katib-db]
 - [kfp-api, kfp-db]
 - [kfp-api:kfp-api, kfp-persistence:kfp-api]
 - [kfp-api:kfp-api, kfp-ui:kfp-api]
 - [kfp-api:kfp-viz, kfp-viz:kfp-viz]
 - [kfp-api:object-storage, minio:object-storage]
+- [kfp-profile-controller:object-storage, minio:object-storage]
 - [kfp-ui:object-storage, minio:object-storage]
 - [kubeflow-profiles, kubeflow-dashboard]
+- [mlmd:grpc, envoy:grpc]

--- a/tests/test_kubectl.py
+++ b/tests/test_kubectl.py
@@ -59,10 +59,9 @@ def test_running_full():
         'minio': 'Running',
         'mlmd': 'Running',
         'oidc-gatekeeper': 'Running',
-        'pytorch-operator': 'Running',
         'seldon-controller-manager': 'Running',
         'spark': 'Running',
-        'tfjob-operator': 'Running',
+        'training-operator': 'Running',
     }
 
 
@@ -90,9 +89,8 @@ def test_running_lite():
         'kfp-ui': 'Running',
         'kfp-viewer': 'Running',
         'kfp-viz': 'Running',
-        'pytorch-operator': 'Running',
         'seldon-controller-manager': 'Running',
-        'tfjob-operator': 'Running',
+        'training-operator': 'Running',
     }
 
 
@@ -106,9 +104,8 @@ def test_running_edge():
         'kfp-persistence': 'Running',
         'kfp-schedwf': 'Running',
         'minio': 'Running',
-        'pytorch-operator': 'Running',
         'seldon-controller-manager': 'Running',
-        'tfjob-operator': 'Running',
+        'training-operator': 'Running',
     }
 
 
@@ -123,16 +120,18 @@ def test_crd_created_full():
             'notebooks.kubeflow.org',
             'poddefaults.kubeflow.org',
             'profiles.kubeflow.org',
-            'pytorchjobs.kubeflow.org',
             'scheduledworkflows.kubeflow.org',
             'seldondeployments.machinelearning.seldon.io',
             'servicerolebindings.rbac.istio.io',
             'serviceroles.rbac.istio.io',
             'suggestions.kubeflow.org',
-            'tfjobs.kubeflow.org',
             'trials.kubeflow.org',
             'viewers.kubeflow.org',
             'workflows.argoproj.io',
+            'xgboostjobs.kubeflow.org',
+            'mxjobs.kubeflow.org',
+            'pytorchjobs.kubeflow.org',
+            'tfjobs.kubeflow.org',
         }
     )
 
@@ -147,14 +146,16 @@ def test_crd_created_lite():
             'notebooks.kubeflow.org',
             'poddefaults.kubeflow.org',
             'profiles.kubeflow.org',
-            'pytorchjobs.kubeflow.org',
             'scheduledworkflows.kubeflow.org',
             'seldondeployments.machinelearning.seldon.io',
             'servicerolebindings.rbac.istio.io',
             'serviceroles.rbac.istio.io',
-            'tfjobs.kubeflow.org',
             'viewers.kubeflow.org',
             'workflows.argoproj.io',
+            'xgboostjobs.kubeflow.org',
+            'mxjobs.kubeflow.org',
+            'pytorchjobs.kubeflow.org',
+            'tfjobs.kubeflow.org',
         }
     )
 
@@ -166,11 +167,13 @@ def test_crd_created_edge():
     names = {i['metadata']['name'] for i in crds['items']}
     assert names.issuperset(
         {
-            'pytorchjobs.kubeflow.org',
             'scheduledworkflows.kubeflow.org',
             'seldondeployments.machinelearning.seldon.io',
-            'tfjobs.kubeflow.org',
             'workflows.argoproj.io',
+            'xgboostjobs.kubeflow.org',
+            'mxjobs.kubeflow.org',
+            'pytorchjobs.kubeflow.org',
+            'tfjobs.kubeflow.org',
         }
     )
 
@@ -226,14 +229,11 @@ def test_service_accounts_created_full():
             'mlmd-operator',
             'oidc-gatekeeper-operator',
             'pipeline-runner',
-            'pytorch-operator',
-            'pytorch-operator-operator',
             'seldon-controller-manager',
             'seldon-controller-manager-operator',
             'spark',
             'spark-operator',
-            'tfjob-operator',
-            'tfjob-operator-operator',
+            'training-operator',
         },
     )
 
@@ -282,12 +282,9 @@ def test_service_accounts_created_lite():
             'mlmd-operator',
             'oidc-gatekeeper-operator',
             'pipeline-runner',
-            'pytorch-operator',
-            'pytorch-operator-operator',
             'seldon-controller-manager',
             'seldon-controller-manager-operator',
-            'tfjob-operator',
-            'tfjob-operator-operator',
+            'training-operator',
         },
     )
 
@@ -311,11 +308,8 @@ def test_service_accounts_created_edge():
             'kfp-schedwf-operator',
             'minio-operator',
             'pipeline-runner',
-            'pytorch-operator',
-            'pytorch-operator-operator',
             'seldon-controller-manager',
             'seldon-controller-manager-operator',
-            'tfjob-operator',
-            'tfjob-operator-operator',
+            'training-operator',
         },
     )


### PR DESCRIPTION
This PR updates publish job and all necessary changes to make it possible to test and push the bundle to Charmhub:
* bundle*.yaml: updates applications repo charmstore -> charmhub
* workflows/publish.yaml: updates publish job with charmhub-upload-action
* tests/test_kubectl.py: enables training-operator checks and removes pytorch/tf