### PR TITLE
move temporary password from CI to secret

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -218,6 +218,8 @@ jobs:
         EOF
 
     - name: Deploy Kubeflow
+      env: 
+        KUBEFLOW_AUTH_PASSWORD: ${{ secrets.KUBEFLOW_AUTH_PASSWORD }}
       run: |
         juju ssh ubuntu/0 <<EOF
           set -eux
@@ -225,7 +227,7 @@ jobs:
           git clone git://git.launchpad.net/canonical-osm
           cp -r canonical-osm/charms/interfaces/juju-relation-mysql mysql
           python3 ./scripts/cli.py microk8s setup --test-mode
-          KUBEFLOW_AUTH_PASSWORD=foobar python3 ./scripts/cli.py --debug deploy-to uk8s --build --bundle ${{ matrix.bundle }}
+          python3 ./scripts/cli.py --debug deploy-to uk8s --build --bundle ${{ matrix.bundle }}
         EOF
 
     - name: Test Kubeflow


### PR DESCRIPTION
CI defines directly as an environment variable a temporary password for deploying Kubeflow. 
 This PR moves it to a secret, which has already been added to the repo.