### PR TITLE
Add warning against using admin as dex-auth username while running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ To deploy this bundle and run tests locally, do the following:
 1. Set up Kubernetes, Juju, and deploy the bundle you're interested in (`kubeflow` or
    `kubeflow-lite`) using the [installation guide](https://charmed-kubeflow.io/docs/install/). This
    must include populating the `.kube/config` file with your Kubernetes cluster as the active
-   context
+   context. Beware of using `admin` as the dex-auth static-username as it conflicts with the
+   `admin` kubernetes profile while running tests below
 1. Install test prerequisites:
 
 ```bash


### PR DESCRIPTION
# Issue
The [kubeflow deploy docs](https://charmed-kubeflow.io/docs/quickstart) uses `admin` as the dex-auth password while deploying kubeflow. This conflicts with the `admin` kubernetes profile while running tests and causes the `pipelines` tests to fail.

# Solution
Update the README to warn against using `admin` as the dex-auth username