### PR TITLE
Add warning about namespace creation before running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ To deploy this bundle and run tests locally, do the following:
 1. Set up Kubernetes, Juju, and deploy the bundle you're interested in (`kubeflow` or
    `kubeflow-lite`) using the [installation guide](https://charmed-kubeflow.io/docs/install/). This
    must include populating the `.kube/config` file with your Kubernetes cluster as the active
-   context. Beware of using `admin` as the dex-auth static-username as the tests attempt to create
-   a profile and `admin` conflicts with an existing default profile.
+   context. Do not create a namespace with the same name as the username, this will cause 
+   pipelines tests to fail. Beware of using `admin` as the dex-auth static-username as the tests 
+   attempt to create a profile and `admin` conflicts with an existing default profile.
 1. Install test prerequisites:
 
-```bash
+   ```bash
    sudo snap install juju-wait --classic
    sudo snap install juju-kubectl --classic
    sudo snap install charmcraft --classic
@@ -40,22 +41,22 @@ To deploy this bundle and run tests locally, do the following:
    sudo apt install -y libssl-dev firefox-geckodriver
    sudo pip3 install tox
    sudo pip3 install -r requirements.txt
-```
+   ```
 
-3. Run tests on your bundle with tox. As many tests need authentication, make sure you pass the
+1. Run tests on your bundle with tox. As many tests need authentication, make sure you pass the
    username and password you set in step (1) through environment variable or argument, for example:
-   1. full bundle (using command line arguments):
+   - full bundle (using command line arguments):
       ```
       tox -e tests -- -m full --username user123@email.com --password user123
       ```
-   1. lite bundle (using environment variables:
+   - lite bundle (using environment variables):
       ```
       export KUBEFLOW_AUTH_USERNAME=user1234@email.com
       export KUBEFLOW_AUTH_PASSWORD=user1234
       tox -e tests -- -m lite
       ```
 
-Subsets of the tests are also available using pytest's substring expression selector (eg:
+Subsets of the tests are also available using pytest's substring expression selector (e.g.:
 `tox -e tests -- -m full --username user123@email.com --password user123 -k 'selenium'` to run just
 the selenium tests).
 


### PR DESCRIPTION
###  Issue
Creating a namespace with the same name as the username leads to pipeline tests to fail.

### Solution
Add a warning in step one. Also fixed some markdown formatting issues across the document.