### PR TITLE
add 1.6 edge and beta bundle files

### DIFF
--- a/releases/1.6/beta/kubeflow-lite/README.md
+++ b/releases/1.6/beta/kubeflow-lite/README.md
@@ -1,0 +1,67 @@
+# Kubeflow Operators
+
+## Introduction
+
+Charmed Kubeflow is a full set of Kubernetes operators to deliver the 30+ applications and services
+that make up the latest version of Kubeflow, for easy operations anywhere, from workstations to
+on-prem, to public cloud and edge.
+
+A charm is a software package that includes an operator together with metadata that supports the
+integration of many operators in a coherent aggregated system.
+
+This technology leverages the Juju Operator Lifecycle Manager to provide day-0 to day-2 operations
+of Kubeflow.
+
+Visit [charmed-kubeflow.io][charmedkf] for more information.
+
+## Install
+
+
+For any Kubernetes, follow the [installation instructions][install].
+
+## Testing
+
+To deploy this bundle and run tests locally, do the following:
+
+1. Set up Kubernetes, Juju, and deploy the bundle you're interested in (`kubeflow` or
+   `kubeflow-lite`) using the [installation guide](https://charmed-kubeflow.io/docs/install/). This
+   must include populating the `.kube/config` file with your Kubernetes cluster as the active
+   context. Do not create a namespace with the same name as the username, this will cause 
+   pipelines tests to fail. Beware of using `admin` as the dex-auth static-username as the tests 
+   attempt to create a profile and `admin` conflicts with an existing default profile.
+1. Install test prerequisites:
+
+   ```bash
+   sudo snap install juju-wait --classic
+   sudo snap install juju-kubectl --classic
+   sudo snap install charmcraft --classic
+   sudo apt update
+   sudo apt install -y libssl-dev firefox-geckodriver
+   sudo pip3 install tox
+   sudo pip3 install -r requirements.txt
+   ```
+
+1. Run tests on your bundle with tox. As many tests need authentication, make sure you pass the
+   username and password you set in step (1) through environment variable or argument, for example:
+   - full bundle (using command line arguments):
+      ```
+      tox -e tests -- -m full --username user123@email.com --password user123
+      ```
+   - lite bundle (using environment variables):
+      ```
+      export KUBEFLOW_AUTH_USERNAME=user1234@email.com
+      export KUBEFLOW_AUTH_PASSWORD=user1234
+      tox -e tests -- -m lite
+      ```
+
+Subsets of the tests are also available using pytest's substring expression selector (e.g.:
+`tox -e tests -- -m full --username user123@email.com --password user123 -k 'selenium'` to run just
+the selenium tests).
+
+## Documentation
+
+Read the [official documentation][docs].
+
+[charmedkf]: https://charmed-kubeflow.io/
+[docs]: https://charmed-kubeflow.io/docs/
+[install]: https://charmed-kubeflow.io/docs/install

--- a/releases/1.6/beta/kubeflow-lite/bundle.yaml
+++ b/releases/1.6/beta/kubeflow-lite/bundle.yaml
@@ -120,7 +120,7 @@ applications:
     _github_repo_name: minio-operator
   oidc-gatekeeper:
     charm: oidc-gatekeeper
-    channel: ckf-1.4/beta
+    channel: latest/beta
     scale: 1
     _github_repo_name: oidc-gatekeeper-operator
   seldon-controller-manager:

--- a/releases/1.6/beta/kubeflow-lite/bundle.yaml
+++ b/releases/1.6/beta/kubeflow-lite/bundle.yaml
@@ -1,0 +1,155 @@
+# Modified from https://github.com/canonical/kubeflow-ci/blob/main/releases/1.4/kubeflow-bundle.yaml
+
+bundle: kubernetes
+name: kubeflow-lite
+applications:
+  admission-webhook:
+    charm: admission-webhook
+    channel: 1.6/beta
+    scale: 1
+    _github_repo_name: admission-webhook-operator
+  argo-controller:
+    charm: argo-controller
+    channel: 3.3/beta
+    scale: 1
+    _github_repo_name: argo-operators
+  dex-auth:
+    charm: dex-auth
+    channel: 2.31/beta
+    scale: 1
+    trust: true
+    _github_repo_name: dex-auth-operator
+  istio-ingressgateway:
+    charm: istio-gateway
+    channel: 1.11/beta
+    scale: 1
+    trust: true
+    _github_repo_name: istio-operators
+    options:
+      kind: ingress
+  istio-pilot:
+    charm: istio-pilot
+    channel: 1.11/beta
+    scale: 1
+    trust: true
+    _github_repo_name: istio-operators
+    options:
+      default-gateway: kubeflow-gateway
+  jupyter-controller:
+    charm: jupyter-controller
+    channel: 1.6/beta
+    scale: 1
+    _github_repo_name: notebook-operators
+  jupyter-ui:
+    charm: jupyter-ui
+    channel: 1.6/beta
+    scale: 1
+    _github_repo_name: notebook-operators
+  kfp-api:
+    charm: kfp-api
+    channel: 2.0/beta
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-db:
+    charm: charmed-osm-mariadb-k8s
+    channel: latest/edge
+    scale: 1
+    options:
+      database: mlpipeline
+  kfp-persistence:
+    charm: kfp-persistence
+    channel: 2.0/beta
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-profile-controller:
+    charm: kfp-profile-controller
+    channel: 2.0/beta
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-schedwf:
+    charm: kfp-schedwf
+    channel: 2.0/beta
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-ui:
+    charm: kfp-ui
+    channel: 2.0/beta
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-viewer:
+    charm: kfp-viewer
+    channel: 2.0/beta
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-viz:
+    charm: kfp-viz
+    channel: 2.0/beta
+    scale: 1
+    _github_repo_name: kfp-operators
+  kubeflow-dashboard:
+    charm: kubeflow-dashboard
+    channel: 1.6/beta
+    scale: 1
+    _github_repo_name: kubeflow-dashboard-operator
+  kubeflow-profiles:
+    charm: kubeflow-profiles
+    channel: 1.6/beta
+    scale: 1
+    _github_repo_name: kubeflow-profiles-operator
+  kubeflow-roles:
+    charm: kubeflow-roles
+    channel: 1.6/beta
+    scale: 1
+    trust: true
+    _github_repo_name: kubeflow-roles-operator
+  kubeflow-volumes:
+    charm: kubeflow-volumes
+    channel: 1.6/beta
+    scale: 1
+    _github_repo_name: kubeflow-volumes-operator
+  metacontroller-operator:
+    charm: metacontroller-operator
+    channel: 2.0/beta
+    scale: 1
+    trust: true
+    _github_repo_name: metacontroller-operator
+  minio:
+    charm: minio
+    channel: latest/edge
+    scale: 1
+    _github_repo_name: minio-operator
+  oidc-gatekeeper:
+    charm: oidc-gatekeeper
+    channel: ckf-1.4/edge
+    scale: 1
+    _github_repo_name: oidc-gatekeeper-operator
+  seldon-controller-manager:
+    charm: seldon-core
+    channel: 1.14/beta
+    scale: 1
+    _github_repo_name: seldon-core-operator
+  training-operator:
+    charm: training-operator
+    channel: 1.5/beta
+    scale: 1
+    trust: true
+    _github_repo_name: training-operator
+relations:
+  - [argo-controller, minio]
+  - [dex-auth:oidc-client, oidc-gatekeeper:oidc-client]
+  - [istio-pilot:ingress, dex-auth:ingress]
+  - [istio-pilot:ingress, jupyter-ui:ingress]
+  - [istio-pilot:ingress, kfp-ui:ingress]
+  - [istio-pilot:ingress, kubeflow-dashboard:ingress]
+  - [istio-pilot:ingress, kubeflow-volumes:ingress]
+  - [istio-pilot:ingress, oidc-gatekeeper:ingress]
+  - [istio-pilot:ingress-auth, oidc-gatekeeper:ingress-auth]
+  - [istio-pilot:istio-pilot, istio-ingressgateway:istio-pilot]
+  - [kfp-api, kfp-db]
+  - [kfp-api:kfp-api, kfp-persistence:kfp-api]
+  - [kfp-api:kfp-api, kfp-ui:kfp-api]
+  - [kfp-api:kfp-viz, kfp-viz:kfp-viz]
+  - [kfp-api:object-storage, minio:object-storage]
+  - [kfp-profile-controller:object-storage, minio:object-storage]
+  - [kfp-ui:object-storage, minio:object-storage]
+  - [kubeflow-profiles, kubeflow-dashboard]

--- a/releases/1.6/beta/kubeflow-lite/bundle.yaml
+++ b/releases/1.6/beta/kubeflow-lite/bundle.yaml
@@ -115,7 +115,7 @@ applications:
     _github_repo_name: metacontroller-operator
   minio:
     charm: minio
-    channel: latest/edge
+    channel: latest/beta
     scale: 1
     _github_repo_name: minio-operator
   oidc-gatekeeper:

--- a/releases/1.6/beta/kubeflow-lite/bundle.yaml
+++ b/releases/1.6/beta/kubeflow-lite/bundle.yaml
@@ -120,7 +120,7 @@ applications:
     _github_repo_name: minio-operator
   oidc-gatekeeper:
     charm: oidc-gatekeeper
-    channel: ckf-1.4/edge
+    channel: ckf-1.4/beta
     scale: 1
     _github_repo_name: oidc-gatekeeper-operator
   seldon-controller-manager:

--- a/releases/1.6/beta/kubeflow-lite/charmcraft.yaml
+++ b/releases/1.6/beta/kubeflow-lite/charmcraft.yaml
@@ -1,0 +1,1 @@
+type: bundle

--- a/releases/1.6/beta/kubeflow/README.md
+++ b/releases/1.6/beta/kubeflow/README.md
@@ -1,0 +1,67 @@
+# Kubeflow Operators
+
+## Introduction
+
+Charmed Kubeflow is a full set of Kubernetes operators to deliver the 30+ applications and services
+that make up the latest version of Kubeflow, for easy operations anywhere, from workstations to
+on-prem, to public cloud and edge.
+
+A charm is a software package that includes an operator together with metadata that supports the
+integration of many operators in a coherent aggregated system.
+
+This technology leverages the Juju Operator Lifecycle Manager to provide day-0 to day-2 operations
+of Kubeflow.
+
+Visit [charmed-kubeflow.io][charmedkf] for more information.
+
+## Install
+
+
+For any Kubernetes, follow the [installation instructions][install].
+
+## Testing
+
+To deploy this bundle and run tests locally, do the following:
+
+1. Set up Kubernetes, Juju, and deploy the bundle you're interested in (`kubeflow` or
+   `kubeflow-lite`) using the [installation guide](https://charmed-kubeflow.io/docs/install/). This
+   must include populating the `.kube/config` file with your Kubernetes cluster as the active
+   context. Do not create a namespace with the same name as the username, this will cause 
+   pipelines tests to fail. Beware of using `admin` as the dex-auth static-username as the tests 
+   attempt to create a profile and `admin` conflicts with an existing default profile.
+1. Install test prerequisites:
+
+   ```bash
+   sudo snap install juju-wait --classic
+   sudo snap install juju-kubectl --classic
+   sudo snap install charmcraft --classic
+   sudo apt update
+   sudo apt install -y libssl-dev firefox-geckodriver
+   sudo pip3 install tox
+   sudo pip3 install -r requirements.txt
+   ```
+
+1. Run tests on your bundle with tox. As many tests need authentication, make sure you pass the
+   username and password you set in step (1) through environment variable or argument, for example:
+   - full bundle (using command line arguments):
+      ```
+      tox -e tests -- -m full --username user123@email.com --password user123
+      ```
+   - lite bundle (using environment variables):
+      ```
+      export KUBEFLOW_AUTH_USERNAME=user1234@email.com
+      export KUBEFLOW_AUTH_PASSWORD=user1234
+      tox -e tests -- -m lite
+      ```
+
+Subsets of the tests are also available using pytest's substring expression selector (e.g.:
+`tox -e tests -- -m full --username user123@email.com --password user123 -k 'selenium'` to run just
+the selenium tests).
+
+## Documentation
+
+Read the [official documentation][docs].
+
+[charmedkf]: https://charmed-kubeflow.io/
+[docs]: https://charmed-kubeflow.io/docs/
+[install]: https://charmed-kubeflow.io/docs/install

--- a/releases/1.6/beta/kubeflow/bundle.yaml
+++ b/releases/1.6/beta/kubeflow/bundle.yaml
@@ -1,0 +1,193 @@
+bundle: kubernetes
+name: kubeflow
+applications:
+  admission-webhook:
+    charm: admission-webhook
+    channel: 1.6/beta
+    scale: 1
+    _github_repo_name: admission-webhook-operator
+  argo-controller:
+    charm: argo-controller
+    channel: 3.3/beta
+    scale: 1
+    _github_repo_name: argo-operators
+  argo-server:
+    charm: argo-server
+    channel: 3.3/beta
+    scale: 1
+    _github_repo_name: argo-operators
+  dex-auth:
+    charm: dex-auth
+    channel: 2.31/beta
+    scale: 1
+    trust: true
+    _github_repo_name: dex-auth-operator
+  istio-ingressgateway:
+    charm: istio-gateway
+    channel: 1.11/beta
+    scale: 1
+    trust: true
+    _github_repo_name: istio-operators
+    options:
+      kind: ingress
+  istio-pilot:
+    charm: istio-pilot
+    channel: 1.11/beta
+    scale: 1
+    trust: true
+    _github_repo_name: istio-operators
+    options:
+      default-gateway: kubeflow-gateway
+  jupyter-controller:
+    charm: jupyter-controller
+    channel: 1.6/beta
+    scale: 1
+    _github_repo_name: notebook-operators
+  jupyter-ui:
+    charm: jupyter-ui
+    channel: 1.6/beta
+    scale: 1
+    _github_repo_name: notebook-operators
+  katib-controller:
+    charm: katib-controller
+    channel: 0.14/beta
+    scale: 1
+    _github_repo_name: katib-operators
+  katib-db:
+    charm: charmed-osm-mariadb-k8s
+    channel: latest/edge
+    scale: 1
+    options:
+      database: katib
+  katib-db-manager:
+    charm: katib-db-manager
+    channel: 0.14/beta
+    scale: 1
+    _github_repo_name: katib-operators
+  katib-ui:
+    charm: katib-ui
+    channel: 0.14/beta
+    scale: 1
+    _github_repo_name: katib-operators
+  kfp-api:
+    charm: kfp-api
+    channel: 2.0/beta
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-db:
+    charm: charmed-osm-mariadb-k8s
+    channel: latest/edge
+    scale: 1
+    options:
+      database: mlpipeline
+  kfp-persistence:
+    charm: kfp-persistence
+    channel: 2.0/beta
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-profile-controller:
+    charm: kfp-profile-controller
+    channel: 2.0/beta
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-schedwf:
+    charm: kfp-schedwf
+    channel: 2.0/beta
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-ui:
+    charm: kfp-ui
+    channel: 2.0/beta
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-viewer:
+    charm: kfp-viewer
+    channel: 2.0/beta
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-viz:
+    charm: kfp-viz
+    channel: 2.0/beta
+    scale: 1
+    _github_repo_name: kfp-operators
+  kubeflow-dashboard:
+    charm: kubeflow-dashboard
+    channel: 1.6/beta
+    scale: 1
+    _github_repo_name: kubeflow-dashboard-operator
+  kubeflow-profiles:
+    charm: kubeflow-profiles
+    channel: 1.6/beta
+    scale: 1
+    _github_repo_name: kubeflow-profiles-operator
+  kubeflow-roles:
+    charm: kubeflow-roles
+    channel: 1.6/beta
+    scale: 1
+    trust: true
+    _github_repo_name: kubeflow-roles-operator
+  kubeflow-volumes:
+    charm: kubeflow-volumes
+    channel: 1.6/beta
+    scale: 1
+    _github_repo_name: kubeflow-volumes-operator
+  metacontroller-operator:
+    charm: metacontroller-operator
+    channel: 2.0/beta
+    scale: 1
+    trust: true
+    _github_repo_name: metacontroller-operator
+  minio:
+    charm: minio
+    channel: latest/edge
+    scale: 1
+    _github_repo_name: minio-operator
+  oidc-gatekeeper:
+    charm: oidc-gatekeeper
+    channel: ckf-1.4/edge
+    scale: 1
+    _github_repo_name: oidc-gatekeeper-operator
+  seldon-controller-manager:
+    charm: seldon-core
+    channel: 1.14/beta
+    scale: 1
+    _github_repo_name: seldon-core-operator
+  tensorboard-controller:
+    charm: tensorboard-controller
+    channel: 1.6/beta
+    scale: 1
+    _github_repo_name: kubeflow-tensorboards-operator
+  tensorboards-web-app:
+    charm: tensorboards-web-app
+    channel: 1.6/beta
+    scale: 1
+    _github_repo_name: kubeflow-tensorboards-operator
+  training-operator:
+    charm: training-operator
+    channel: 1.5/beta
+    scale: 1
+    trust: true
+    _github_repo_name: training-operator
+relations:
+  - [argo-controller, minio]
+  - [dex-auth:oidc-client, oidc-gatekeeper:oidc-client]
+  - [istio-pilot:ingress, dex-auth:ingress]
+  - [istio-pilot:ingress, jupyter-ui:ingress]
+  - [istio-pilot:ingress, katib-ui:ingress]
+  - [istio-pilot:ingress, kfp-ui:ingress]
+  - [istio-pilot:ingress, kubeflow-dashboard:ingress]
+  - [istio-pilot:ingress, kubeflow-volumes:ingress]
+  - [istio-pilot:ingress, oidc-gatekeeper:ingress]
+  - [istio-pilot:ingress-auth, oidc-gatekeeper:ingress-auth]
+  - [istio-pilot:istio-pilot, istio-ingressgateway:istio-pilot]
+  - [istio-pilot:ingress, tensorboards-web-app:ingress]
+  - [istio-pilot:gateway, tensorboard-controller:gateway]
+  - [katib-db-manager, katib-db]
+  - [kfp-api, kfp-db]
+  - [kfp-api:kfp-api, kfp-persistence:kfp-api]
+  - [kfp-api:kfp-api, kfp-ui:kfp-api]
+  - [kfp-api:kfp-viz, kfp-viz:kfp-viz]
+  - [kfp-api:object-storage, minio:object-storage]
+  - [kfp-profile-controller:object-storage, minio:object-storage]
+  - [kfp-ui:object-storage, minio:object-storage]
+  - [kubeflow-profiles, kubeflow-dashboard]

--- a/releases/1.6/beta/kubeflow/bundle.yaml
+++ b/releases/1.6/beta/kubeflow/bundle.yaml
@@ -144,7 +144,7 @@ applications:
     _github_repo_name: minio-operator
   oidc-gatekeeper:
     charm: oidc-gatekeeper
-    channel: ckf-1.4/beta
+    channel: latest/beta
     scale: 1
     _github_repo_name: oidc-gatekeeper-operator
   seldon-controller-manager:

--- a/releases/1.6/beta/kubeflow/bundle.yaml
+++ b/releases/1.6/beta/kubeflow/bundle.yaml
@@ -139,7 +139,7 @@ applications:
     _github_repo_name: metacontroller-operator
   minio:
     charm: minio
-    channel: latest/edge
+    channel: latest/beta
     scale: 1
     _github_repo_name: minio-operator
   oidc-gatekeeper:

--- a/releases/1.6/beta/kubeflow/bundle.yaml
+++ b/releases/1.6/beta/kubeflow/bundle.yaml
@@ -144,7 +144,7 @@ applications:
     _github_repo_name: minio-operator
   oidc-gatekeeper:
     charm: oidc-gatekeeper
-    channel: ckf-1.4/edge
+    channel: ckf-1.4/beta
     scale: 1
     _github_repo_name: oidc-gatekeeper-operator
   seldon-controller-manager:

--- a/releases/1.6/beta/kubeflow/charmcraft.yaml
+++ b/releases/1.6/beta/kubeflow/charmcraft.yaml
@@ -1,0 +1,1 @@
+type: bundle

--- a/releases/1.6/edge/kubeflow-lite/README.md
+++ b/releases/1.6/edge/kubeflow-lite/README.md
@@ -1,0 +1,67 @@
+# Kubeflow Operators
+
+## Introduction
+
+Charmed Kubeflow is a full set of Kubernetes operators to deliver the 30+ applications and services
+that make up the latest version of Kubeflow, for easy operations anywhere, from workstations to
+on-prem, to public cloud and edge.
+
+A charm is a software package that includes an operator together with metadata that supports the
+integration of many operators in a coherent aggregated system.
+
+This technology leverages the Juju Operator Lifecycle Manager to provide day-0 to day-2 operations
+of Kubeflow.
+
+Visit [charmed-kubeflow.io][charmedkf] for more information.
+
+## Install
+
+
+For any Kubernetes, follow the [installation instructions][install].
+
+## Testing
+
+To deploy this bundle and run tests locally, do the following:
+
+1. Set up Kubernetes, Juju, and deploy the bundle you're interested in (`kubeflow` or
+   `kubeflow-lite`) using the [installation guide](https://charmed-kubeflow.io/docs/install/). This
+   must include populating the `.kube/config` file with your Kubernetes cluster as the active
+   context. Do not create a namespace with the same name as the username, this will cause 
+   pipelines tests to fail. Beware of using `admin` as the dex-auth static-username as the tests 
+   attempt to create a profile and `admin` conflicts with an existing default profile.
+1. Install test prerequisites:
+
+   ```bash
+   sudo snap install juju-wait --classic
+   sudo snap install juju-kubectl --classic
+   sudo snap install charmcraft --classic
+   sudo apt update
+   sudo apt install -y libssl-dev firefox-geckodriver
+   sudo pip3 install tox
+   sudo pip3 install -r requirements.txt
+   ```
+
+1. Run tests on your bundle with tox. As many tests need authentication, make sure you pass the
+   username and password you set in step (1) through environment variable or argument, for example:
+   - full bundle (using command line arguments):
+      ```
+      tox -e tests -- -m full --username user123@email.com --password user123
+      ```
+   - lite bundle (using environment variables):
+      ```
+      export KUBEFLOW_AUTH_USERNAME=user1234@email.com
+      export KUBEFLOW_AUTH_PASSWORD=user1234
+      tox -e tests -- -m lite
+      ```
+
+Subsets of the tests are also available using pytest's substring expression selector (e.g.:
+`tox -e tests -- -m full --username user123@email.com --password user123 -k 'selenium'` to run just
+the selenium tests).
+
+## Documentation
+
+Read the [official documentation][docs].
+
+[charmedkf]: https://charmed-kubeflow.io/
+[docs]: https://charmed-kubeflow.io/docs/
+[install]: https://charmed-kubeflow.io/docs/install

--- a/releases/1.6/edge/kubeflow-lite/bundle.yaml
+++ b/releases/1.6/edge/kubeflow-lite/bundle.yaml
@@ -1,0 +1,155 @@
+# Modified from https://github.com/canonical/kubeflow-ci/blob/main/releases/1.4/kubeflow-bundle.yaml
+
+bundle: kubernetes
+name: kubeflow-lite
+applications:
+  admission-webhook:
+    charm: admission-webhook
+    channel: 1.6/edge
+    scale: 1
+    _github_repo_name: admission-webhook-operator
+  argo-controller:
+    charm: argo-controller
+    channel: 3.3/edge
+    scale: 1
+    _github_repo_name: argo-operators
+  dex-auth:
+    charm: dex-auth
+    channel: 2.31/edge
+    scale: 1
+    trust: true
+    _github_repo_name: dex-auth-operator
+  istio-ingressgateway:
+    charm: istio-gateway
+    channel: 1.11/edge
+    scale: 1
+    trust: true
+    _github_repo_name: istio-operators
+    options:
+      kind: ingress
+  istio-pilot:
+    charm: istio-pilot
+    channel: 1.11/edge
+    scale: 1
+    trust: true
+    _github_repo_name: istio-operators
+    options:
+      default-gateway: kubeflow-gateway
+  jupyter-controller:
+    charm: jupyter-controller
+    channel: 1.6/edge
+    scale: 1
+    _github_repo_name: notebook-operators
+  jupyter-ui:
+    charm: jupyter-ui
+    channel: 1.6/edge
+    scale: 1
+    _github_repo_name: notebook-operators
+  kfp-api:
+    charm: kfp-api
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-db:
+    charm: charmed-osm-mariadb-k8s
+    channel: latest/edge
+    scale: 1
+    options:
+      database: mlpipeline
+  kfp-persistence:
+    charm: kfp-persistence
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-profile-controller:
+    charm: kfp-profile-controller
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-schedwf:
+    charm: kfp-schedwf
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-ui:
+    charm: kfp-ui
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-viewer:
+    charm: kfp-viewer
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-viz:
+    charm: kfp-viz
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kubeflow-dashboard:
+    charm: kubeflow-dashboard
+    channel: 1.6/edge
+    scale: 1
+    _github_repo_name: kubeflow-dashboard-operator
+  kubeflow-profiles:
+    charm: kubeflow-profiles
+    channel: 1.6/edge
+    scale: 1
+    _github_repo_name: kubeflow-profiles-operator
+  kubeflow-roles:
+    charm: kubeflow-roles
+    channel: 1.6/edge
+    scale: 1
+    trust: true
+    _github_repo_name: kubeflow-roles-operator
+  kubeflow-volumes:
+    charm: kubeflow-volumes
+    channel: 1.6/edge
+    scale: 1
+    _github_repo_name: kubeflow-volumes-operator
+  metacontroller-operator:
+    charm: metacontroller-operator
+    channel: 2.0/edge
+    scale: 1
+    trust: true
+    _github_repo_name: metacontroller-operator
+  minio:
+    charm: minio
+    channel: latest/edge
+    scale: 1
+    _github_repo_name: minio-operator
+  oidc-gatekeeper:
+    charm: oidc-gatekeeper
+    channel: ckf-1.4/edge
+    scale: 1
+    _github_repo_name: oidc-gatekeeper-operator
+  seldon-controller-manager:
+    charm: seldon-core
+    channel: 1.14/edge
+    scale: 1
+    _github_repo_name: seldon-core-operator
+  training-operator:
+    charm: training-operator
+    channel: 1.5/edge
+    scale: 1
+    trust: true
+    _github_repo_name: training-operator
+relations:
+  - [argo-controller, minio]
+  - [dex-auth:oidc-client, oidc-gatekeeper:oidc-client]
+  - [istio-pilot:ingress, dex-auth:ingress]
+  - [istio-pilot:ingress, jupyter-ui:ingress]
+  - [istio-pilot:ingress, kfp-ui:ingress]
+  - [istio-pilot:ingress, kubeflow-dashboard:ingress]
+  - [istio-pilot:ingress, kubeflow-volumes:ingress]
+  - [istio-pilot:ingress, oidc-gatekeeper:ingress]
+  - [istio-pilot:ingress-auth, oidc-gatekeeper:ingress-auth]
+  - [istio-pilot:istio-pilot, istio-ingressgateway:istio-pilot]
+  - [kfp-api, kfp-db]
+  - [kfp-api:kfp-api, kfp-persistence:kfp-api]
+  - [kfp-api:kfp-api, kfp-ui:kfp-api]
+  - [kfp-api:kfp-viz, kfp-viz:kfp-viz]
+  - [kfp-api:object-storage, minio:object-storage]
+  - [kfp-profile-controller:object-storage, minio:object-storage]
+  - [kfp-ui:object-storage, minio:object-storage]
+  - [kubeflow-profiles, kubeflow-dashboard]

--- a/releases/1.6/edge/kubeflow-lite/bundle.yaml
+++ b/releases/1.6/edge/kubeflow-lite/bundle.yaml
@@ -120,7 +120,7 @@ applications:
     _github_repo_name: minio-operator
   oidc-gatekeeper:
     charm: oidc-gatekeeper
-    channel: ckf-1.4/edge
+    channel: latest/edge
     scale: 1
     _github_repo_name: oidc-gatekeeper-operator
   seldon-controller-manager:

--- a/releases/1.6/edge/kubeflow-lite/charmcraft.yaml
+++ b/releases/1.6/edge/kubeflow-lite/charmcraft.yaml
@@ -1,0 +1,1 @@
+type: bundle

--- a/releases/1.6/edge/kubeflow/README.md
+++ b/releases/1.6/edge/kubeflow/README.md
@@ -1,0 +1,67 @@
+# Kubeflow Operators
+
+## Introduction
+
+Charmed Kubeflow is a full set of Kubernetes operators to deliver the 30+ applications and services
+that make up the latest version of Kubeflow, for easy operations anywhere, from workstations to
+on-prem, to public cloud and edge.
+
+A charm is a software package that includes an operator together with metadata that supports the
+integration of many operators in a coherent aggregated system.
+
+This technology leverages the Juju Operator Lifecycle Manager to provide day-0 to day-2 operations
+of Kubeflow.
+
+Visit [charmed-kubeflow.io][charmedkf] for more information.
+
+## Install
+
+
+For any Kubernetes, follow the [installation instructions][install].
+
+## Testing
+
+To deploy this bundle and run tests locally, do the following:
+
+1. Set up Kubernetes, Juju, and deploy the bundle you're interested in (`kubeflow` or
+   `kubeflow-lite`) using the [installation guide](https://charmed-kubeflow.io/docs/install/). This
+   must include populating the `.kube/config` file with your Kubernetes cluster as the active
+   context. Do not create a namespace with the same name as the username, this will cause 
+   pipelines tests to fail. Beware of using `admin` as the dex-auth static-username as the tests 
+   attempt to create a profile and `admin` conflicts with an existing default profile.
+1. Install test prerequisites:
+
+   ```bash
+   sudo snap install juju-wait --classic
+   sudo snap install juju-kubectl --classic
+   sudo snap install charmcraft --classic
+   sudo apt update
+   sudo apt install -y libssl-dev firefox-geckodriver
+   sudo pip3 install tox
+   sudo pip3 install -r requirements.txt
+   ```
+
+1. Run tests on your bundle with tox. As many tests need authentication, make sure you pass the
+   username and password you set in step (1) through environment variable or argument, for example:
+   - full bundle (using command line arguments):
+      ```
+      tox -e tests -- -m full --username user123@email.com --password user123
+      ```
+   - lite bundle (using environment variables):
+      ```
+      export KUBEFLOW_AUTH_USERNAME=user1234@email.com
+      export KUBEFLOW_AUTH_PASSWORD=user1234
+      tox -e tests -- -m lite
+      ```
+
+Subsets of the tests are also available using pytest's substring expression selector (e.g.:
+`tox -e tests -- -m full --username user123@email.com --password user123 -k 'selenium'` to run just
+the selenium tests).
+
+## Documentation
+
+Read the [official documentation][docs].
+
+[charmedkf]: https://charmed-kubeflow.io/
+[docs]: https://charmed-kubeflow.io/docs/
+[install]: https://charmed-kubeflow.io/docs/install

--- a/releases/1.6/edge/kubeflow/bundle.yaml
+++ b/releases/1.6/edge/kubeflow/bundle.yaml
@@ -144,7 +144,7 @@ applications:
     _github_repo_name: minio-operator
   oidc-gatekeeper:
     charm: oidc-gatekeeper
-    channel: ckf-1.4/edge
+    channel: latest/edge
     scale: 1
     _github_repo_name: oidc-gatekeeper-operator
   seldon-controller-manager:

--- a/releases/1.6/edge/kubeflow/bundle.yaml
+++ b/releases/1.6/edge/kubeflow/bundle.yaml
@@ -1,0 +1,193 @@
+bundle: kubernetes
+name: kubeflow
+applications:
+  admission-webhook:
+    charm: admission-webhook
+    channel: 1.6/edge
+    scale: 1
+    _github_repo_name: admission-webhook-operator
+  argo-controller:
+    charm: argo-controller
+    channel: 3.3/edge
+    scale: 1
+    _github_repo_name: argo-operators
+  argo-server:
+    charm: argo-server
+    channel: 3.3/edge
+    scale: 1
+    _github_repo_name: argo-operators
+  dex-auth:
+    charm: dex-auth
+    channel: 2.31/edge
+    scale: 1
+    trust: true
+    _github_repo_name: dex-auth-operator
+  istio-ingressgateway:
+    charm: istio-gateway
+    channel: 1.11/edge
+    scale: 1
+    trust: true
+    _github_repo_name: istio-operators
+    options:
+      kind: ingress
+  istio-pilot:
+    charm: istio-pilot
+    channel: 1.11/edge
+    scale: 1
+    trust: true
+    _github_repo_name: istio-operators
+    options:
+      default-gateway: kubeflow-gateway
+  jupyter-controller:
+    charm: jupyter-controller
+    channel: 1.6/edge
+    scale: 1
+    _github_repo_name: notebook-operators
+  jupyter-ui:
+    charm: jupyter-ui
+    channel: 1.6/edge
+    scale: 1
+    _github_repo_name: notebook-operators
+  katib-controller:
+    charm: katib-controller
+    channel: 0.14/edge
+    scale: 1
+    _github_repo_name: katib-operators
+  katib-db:
+    charm: charmed-osm-mariadb-k8s
+    channel: latest/edge
+    scale: 1
+    options:
+      database: katib
+  katib-db-manager:
+    charm: katib-db-manager
+    channel: 0.14/edge
+    scale: 1
+    _github_repo_name: katib-operators
+  katib-ui:
+    charm: katib-ui
+    channel: 0.14/edge
+    scale: 1
+    _github_repo_name: katib-operators
+  kfp-api:
+    charm: kfp-api
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-db:
+    charm: charmed-osm-mariadb-k8s
+    channel: latest/edge
+    scale: 1
+    options:
+      database: mlpipeline
+  kfp-persistence:
+    charm: kfp-persistence
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-profile-controller:
+    charm: kfp-profile-controller
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-schedwf:
+    charm: kfp-schedwf
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-ui:
+    charm: kfp-ui
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-viewer:
+    charm: kfp-viewer
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-viz:
+    charm: kfp-viz
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kubeflow-dashboard:
+    charm: kubeflow-dashboard
+    channel: 1.6/edge
+    scale: 1
+    _github_repo_name: kubeflow-dashboard-operator
+  kubeflow-profiles:
+    charm: kubeflow-profiles
+    channel: 1.6/edge
+    scale: 1
+    _github_repo_name: kubeflow-profiles-operator
+  kubeflow-roles:
+    charm: kubeflow-roles
+    channel: 1.6/edge
+    scale: 1
+    trust: true
+    _github_repo_name: kubeflow-roles-operator
+  kubeflow-volumes:
+    charm: kubeflow-volumes
+    channel: 1.6/edge
+    scale: 1
+    _github_repo_name: kubeflow-volumes-operator
+  metacontroller-operator:
+    charm: metacontroller-operator
+    channel: 2.0/edge
+    scale: 1
+    trust: true
+    _github_repo_name: metacontroller-operator
+  minio:
+    charm: minio
+    channel: latest/edge
+    scale: 1
+    _github_repo_name: minio-operator
+  oidc-gatekeeper:
+    charm: oidc-gatekeeper
+    channel: ckf-1.4/edge
+    scale: 1
+    _github_repo_name: oidc-gatekeeper-operator
+  seldon-controller-manager:
+    charm: seldon-core
+    channel: 1.14/edge
+    scale: 1
+    _github_repo_name: seldon-core-operator
+  tensorboard-controller:
+    charm: tensorboard-controller
+    channel: 1.6/edge
+    scale: 1
+    _github_repo_name: kubeflow-tensorboards-operator
+  tensorboards-web-app:
+    charm: tensorboards-web-app
+    channel: 1.6/edge
+    scale: 1
+    _github_repo_name: kubeflow-tensorboards-operator
+  training-operator:
+    charm: training-operator
+    channel: 1.5/edge
+    scale: 1
+    trust: true
+    _github_repo_name: training-operator
+relations:
+  - [argo-controller, minio]
+  - [dex-auth:oidc-client, oidc-gatekeeper:oidc-client]
+  - [istio-pilot:ingress, dex-auth:ingress]
+  - [istio-pilot:ingress, jupyter-ui:ingress]
+  - [istio-pilot:ingress, katib-ui:ingress]
+  - [istio-pilot:ingress, kfp-ui:ingress]
+  - [istio-pilot:ingress, kubeflow-dashboard:ingress]
+  - [istio-pilot:ingress, kubeflow-volumes:ingress]
+  - [istio-pilot:ingress, oidc-gatekeeper:ingress]
+  - [istio-pilot:ingress-auth, oidc-gatekeeper:ingress-auth]
+  - [istio-pilot:istio-pilot, istio-ingressgateway:istio-pilot]
+  - [istio-pilot:ingress, tensorboards-web-app:ingress]
+  - [istio-pilot:gateway, tensorboard-controller:gateway]
+  - [katib-db-manager, katib-db]
+  - [kfp-api, kfp-db]
+  - [kfp-api:kfp-api, kfp-persistence:kfp-api]
+  - [kfp-api:kfp-api, kfp-ui:kfp-api]
+  - [kfp-api:kfp-viz, kfp-viz:kfp-viz]
+  - [kfp-api:object-storage, minio:object-storage]
+  - [kfp-profile-controller:object-storage, minio:object-storage]
+  - [kfp-ui:object-storage, minio:object-storage]
+  - [kubeflow-profiles, kubeflow-dashboard]

--- a/releases/1.6/edge/kubeflow/charmcraft.yaml
+++ b/releases/1.6/edge/kubeflow/charmcraft.yaml
@@ -1,0 +1,1 @@
+type: bundle


### PR DESCRIPTION
Create edge and beta bundle files with upgraded components versions
> NOTE: unchecked items are the ones whose version is still under discussion/missing, and thus it hasn't been updated in the bundles definition. Check the item ONLY after modifying the bundle files.

- [x] mlmd ([1.9.0 latest release](https://github.com/google/ml-metadata/releases/tag/v1.9.0)) (current version 1.0.0, next version ?) -> not included in the bundle
- [x] minio -> no version, latest/edge, stays the same
- [x] oidc-gatekeeper - this component's upgrade is a nice to have, see kubeflow/manifests#2150 for more info -> ckf-1.4/edge as no upgrades were merged in upstream
- [x] envoy-operator ([1.20.6 latest release](https://github.com/envoyproxy/envoy/releases/tag/v1.20.6)) (current version 1.12.2, next version ?) -> not included in the bundle
- [x] katib-db points to charmed-osm-mariadb-k8s - stays the same
- [x] kfp-db points to charmed-osm-mariadb-k8s - stays the same
- [x] argo-operators 3.3 ([3.3.8](https://github.com/argoproj/argo-workflows/releases/tag/v3.3.8))
- [x] dex-auth-operator 2.31 - as in kubeflow/manifests#2243
- [x] istio-operators 1.11 - Upstream will support 1.13
- [x] metacontroller-operator v2.0.4 ([4.2.1 latest release](https://github.com/metacontroller/metacontroller/releases/tag/v4.2.1))
- [x] seldon-core-operator 1.14 ([1.14.0 latest release](https://github.com/SeldonIO/seldon-core/releases/tag/v1.14.0))

The following versions were extracted from [kubeflow/manifests README.md](https://github.com/kubeflow/manifests/#kubeflow-components-versions) and kubeflow/manifests#2242:
- [x] training-operator 1.5 ([1.5.0-rc0 release](https://github.com/kubeflow/training-operator/releases/tag/v1.5.0-rc.0))
- [x] katib 0.14 ([0.14.0 release](https://github.com/kubeflow/katib/releases/tag/v0.14.0-rc.0))
- [x] notebook-operators 1.6
- [x] kubeflow-dashboard-operator 1.6
- [x] kubeflow-profiles-operator 1.6
- [x] kubeflow-tensorboard-operators 1.6
- [x] kubeflow-volumes-operator 1.6
- [x] kubeflow-roles-operator 1.6
- [x] kfp-operators 2.0 (see kubeflow/manifests#2200 for more info)
- [x] admission-webhook-operator 1.6

#### Useful links
- kubeflow/manifests#2207
- kubeflow/manifests#2194
- Kubernetes deprecation [guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/)