### PR TITLE
feat: add stable 1.6 bundle definitions

### DIFF
--- a/releases/1.6/stable/kubeflow-lite/README.md
+++ b/releases/1.6/stable/kubeflow-lite/README.md
@@ -1,0 +1,67 @@
+# Kubeflow Operators
+
+## Introduction
+
+Charmed Kubeflow is a full set of Kubernetes operators to deliver the 30+ applications and services
+that make up the latest version of Kubeflow, for easy operations anywhere, from workstations to
+on-prem, to public cloud and edge.
+
+A charm is a software package that includes an operator together with metadata that supports the
+integration of many operators in a coherent aggregated system.
+
+This technology leverages the Juju Operator Lifecycle Manager to provide day-0 to day-2 operations
+of Kubeflow.
+
+Visit [charmed-kubeflow.io][charmedkf] for more information.
+
+## Install
+
+
+For any Kubernetes, follow the [installation instructions][install].
+
+## Testing
+
+To deploy this bundle and run tests locally, do the following:
+
+1. Set up Kubernetes, Juju, and deploy the bundle you're interested in (`kubeflow` or
+   `kubeflow-lite`) using the [installation guide](https://charmed-kubeflow.io/docs/install/). This
+   must include populating the `.kube/config` file with your Kubernetes cluster as the active
+   context. Do not create a namespace with the same name as the username, this will cause 
+   pipelines tests to fail. Beware of using `admin` as the dex-auth static-username as the tests 
+   attempt to create a profile and `admin` conflicts with an existing default profile.
+1. Install test prerequisites:
+
+   ```bash
+   sudo snap install juju-wait --classic
+   sudo snap install juju-kubectl --classic
+   sudo snap install charmcraft --classic
+   sudo apt update
+   sudo apt install -y libssl-dev firefox-geckodriver
+   sudo pip3 install tox
+   sudo pip3 install -r requirements.txt
+   ```
+
+1. Run tests on your bundle with tox. As many tests need authentication, make sure you pass the
+   username and password you set in step (1) through environment variable or argument, for example:
+   - full bundle (using command line arguments):
+      ```
+      tox -e tests -- -m full --username user123@email.com --password user123
+      ```
+   - lite bundle (using environment variables):
+      ```
+      export KUBEFLOW_AUTH_USERNAME=user1234@email.com
+      export KUBEFLOW_AUTH_PASSWORD=user1234
+      tox -e tests -- -m lite
+      ```
+
+Subsets of the tests are also available using pytest's substring expression selector (e.g.:
+`tox -e tests -- -m full --username user123@email.com --password user123 -k 'selenium'` to run just
+the selenium tests).
+
+## Documentation
+
+Read the [official documentation][docs].
+
+[charmedkf]: https://charmed-kubeflow.io/
+[docs]: https://charmed-kubeflow.io/docs/
+[install]: https://charmed-kubeflow.io/docs/install

--- a/releases/1.6/stable/kubeflow-lite/bundle.yaml
+++ b/releases/1.6/stable/kubeflow-lite/bundle.yaml
@@ -1,0 +1,155 @@
+# Modified from https://github.com/canonical/kubeflow-ci/blob/main/releases/1.4/kubeflow-bundle.yaml
+
+bundle: kubernetes
+name: kubeflow-lite
+applications:
+  admission-webhook:
+    charm: admission-webhook
+    channel: 1.6/stable
+    scale: 1
+    _github_repo_name: admission-webhook-operator
+  argo-controller:
+    charm: argo-controller
+    channel: 3.3/stable
+    scale: 1
+    _github_repo_name: argo-operators
+  dex-auth:
+    charm: dex-auth
+    channel: 2.31/stable
+    scale: 1
+    trust: true
+    _github_repo_name: dex-auth-operator
+  istio-ingressgateway:
+    charm: istio-gateway
+    channel: 1.11/stable
+    scale: 1
+    trust: true
+    _github_repo_name: istio-operators
+    options:
+      kind: ingress
+  istio-pilot:
+    charm: istio-pilot
+    channel: 1.11/stable
+    scale: 1
+    trust: true
+    _github_repo_name: istio-operators
+    options:
+      default-gateway: kubeflow-gateway
+  jupyter-controller:
+    charm: jupyter-controller
+    channel: 1.6/stable
+    scale: 1
+    _github_repo_name: notebook-operators
+  jupyter-ui:
+    charm: jupyter-ui
+    channel: 1.6/stable
+    scale: 1
+    _github_repo_name: notebook-operators
+  kfp-api:
+    charm: kfp-api
+    channel: 2.0/stable
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-db:
+    charm: charmed-osm-mariadb-k8s
+    channel: latest/stable
+    scale: 1
+    options:
+      database: mlpipeline
+  kfp-persistence:
+    charm: kfp-persistence
+    channel: 2.0/stable
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-profile-controller:
+    charm: kfp-profile-controller
+    channel: 2.0/stable
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-schedwf:
+    charm: kfp-schedwf
+    channel: 2.0/stable
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-ui:
+    charm: kfp-ui
+    channel: 2.0/stable
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-viewer:
+    charm: kfp-viewer
+    channel: 2.0/stable
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-viz:
+    charm: kfp-viz
+    channel: 2.0/stable
+    scale: 1
+    _github_repo_name: kfp-operators
+  kubeflow-dashboard:
+    charm: kubeflow-dashboard
+    channel: 1.6/stable
+    scale: 1
+    _github_repo_name: kubeflow-dashboard-operator
+  kubeflow-profiles:
+    charm: kubeflow-profiles
+    channel: 1.6/stable
+    scale: 1
+    _github_repo_name: kubeflow-profiles-operator
+  kubeflow-roles:
+    charm: kubeflow-roles
+    channel: 1.6/stable
+    scale: 1
+    trust: true
+    _github_repo_name: kubeflow-roles-operator
+  kubeflow-volumes:
+    charm: kubeflow-volumes
+    channel: 1.6/stable
+    scale: 1
+    _github_repo_name: kubeflow-volumes-operator
+  metacontroller-operator:
+    charm: metacontroller-operator
+    channel: 2.0/stable
+    scale: 1
+    trust: true
+    _github_repo_name: metacontroller-operator
+  minio:
+    charm: minio
+    channel: ckf-1.6/stable
+    scale: 1
+    _github_repo_name: minio-operator
+  oidc-gatekeeper:
+    charm: oidc-gatekeeper
+    channel: ckf-1.6/stable
+    scale: 1
+    _github_repo_name: oidc-gatekeeper-operator
+  seldon-controller-manager:
+    charm: seldon-core
+    channel: 1.14/stable
+    scale: 1
+    _github_repo_name: seldon-core-operator
+  training-operator:
+    charm: training-operator
+    channel: 1.5/stable
+    scale: 1
+    trust: true
+    _github_repo_name: training-operator
+relations:
+  - [argo-controller, minio]
+  - [dex-auth:oidc-client, oidc-gatekeeper:oidc-client]
+  - [istio-pilot:ingress, dex-auth:ingress]
+  - [istio-pilot:ingress, jupyter-ui:ingress]
+  - [istio-pilot:ingress, kfp-ui:ingress]
+  - [istio-pilot:ingress, kubeflow-dashboard:ingress]
+  - [istio-pilot:ingress, kubeflow-volumes:ingress]
+  - [istio-pilot:ingress, oidc-gatekeeper:ingress]
+  - [istio-pilot:ingress-auth, oidc-gatekeeper:ingress-auth]
+  - [istio-pilot:istio-pilot, istio-ingressgateway:istio-pilot]
+  - [kfp-api, kfp-db]
+  - [kfp-api:kfp-api, kfp-persistence:kfp-api]
+  - [kfp-api:kfp-api, kfp-ui:kfp-api]
+  - [kfp-api:kfp-viz, kfp-viz:kfp-viz]
+  - [kfp-api:object-storage, minio:object-storage]
+  - [kfp-profile-controller:object-storage, minio:object-storage]
+  - [kfp-ui:object-storage, minio:object-storage]
+  - [kubeflow-profiles, kubeflow-dashboard]

--- a/releases/1.6/stable/kubeflow-lite/charmcraft.yaml
+++ b/releases/1.6/stable/kubeflow-lite/charmcraft.yaml
@@ -1,0 +1,1 @@
+type: bundle

--- a/releases/1.6/stable/kubeflow/README.md
+++ b/releases/1.6/stable/kubeflow/README.md
@@ -1,0 +1,67 @@
+# Kubeflow Operators
+
+## Introduction
+
+Charmed Kubeflow is a full set of Kubernetes operators to deliver the 30+ applications and services
+that make up the latest version of Kubeflow, for easy operations anywhere, from workstations to
+on-prem, to public cloud and edge.
+
+A charm is a software package that includes an operator together with metadata that supports the
+integration of many operators in a coherent aggregated system.
+
+This technology leverages the Juju Operator Lifecycle Manager to provide day-0 to day-2 operations
+of Kubeflow.
+
+Visit [charmed-kubeflow.io][charmedkf] for more information.
+
+## Install
+
+
+For any Kubernetes, follow the [installation instructions][install].
+
+## Testing
+
+To deploy this bundle and run tests locally, do the following:
+
+1. Set up Kubernetes, Juju, and deploy the bundle you're interested in (`kubeflow` or
+   `kubeflow-lite`) using the [installation guide](https://charmed-kubeflow.io/docs/install/). This
+   must include populating the `.kube/config` file with your Kubernetes cluster as the active
+   context. Do not create a namespace with the same name as the username, this will cause 
+   pipelines tests to fail. Beware of using `admin` as the dex-auth static-username as the tests 
+   attempt to create a profile and `admin` conflicts with an existing default profile.
+1. Install test prerequisites:
+
+   ```bash
+   sudo snap install juju-wait --classic
+   sudo snap install juju-kubectl --classic
+   sudo snap install charmcraft --classic
+   sudo apt update
+   sudo apt install -y libssl-dev firefox-geckodriver
+   sudo pip3 install tox
+   sudo pip3 install -r requirements.txt
+   ```
+
+1. Run tests on your bundle with tox. As many tests need authentication, make sure you pass the
+   username and password you set in step (1) through environment variable or argument, for example:
+   - full bundle (using command line arguments):
+      ```
+      tox -e tests -- -m full --username user123@email.com --password user123
+      ```
+   - lite bundle (using environment variables):
+      ```
+      export KUBEFLOW_AUTH_USERNAME=user1234@email.com
+      export KUBEFLOW_AUTH_PASSWORD=user1234
+      tox -e tests -- -m lite
+      ```
+
+Subsets of the tests are also available using pytest's substring expression selector (e.g.:
+`tox -e tests -- -m full --username user123@email.com --password user123 -k 'selenium'` to run just
+the selenium tests).
+
+## Documentation
+
+Read the [official documentation][docs].
+
+[charmedkf]: https://charmed-kubeflow.io/
+[docs]: https://charmed-kubeflow.io/docs/
+[install]: https://charmed-kubeflow.io/docs/install

--- a/releases/1.6/stable/kubeflow/bundle.yaml
+++ b/releases/1.6/stable/kubeflow/bundle.yaml
@@ -1,0 +1,193 @@
+bundle: kubernetes
+name: kubeflow
+applications:
+  admission-webhook:
+    charm: admission-webhook
+    channel: 1.6/stable
+    scale: 1
+    _github_repo_name: admission-webhook-operator
+  argo-controller:
+    charm: argo-controller
+    channel: 3.3/stable
+    scale: 1
+    _github_repo_name: argo-operators
+  argo-server:
+    charm: argo-server
+    channel: 3.3/stable
+    scale: 1
+    _github_repo_name: argo-operators
+  dex-auth:
+    charm: dex-auth
+    channel: 2.31/stable
+    scale: 1
+    trust: true
+    _github_repo_name: dex-auth-operator
+  istio-ingressgateway:
+    charm: istio-gateway
+    channel: 1.11/stable
+    scale: 1
+    trust: true
+    _github_repo_name: istio-operators
+    options:
+      kind: ingress
+  istio-pilot:
+    charm: istio-pilot
+    channel: 1.11/stable
+    scale: 1
+    trust: true
+    _github_repo_name: istio-operators
+    options:
+      default-gateway: kubeflow-gateway
+  jupyter-controller:
+    charm: jupyter-controller
+    channel: 1.6/stable
+    scale: 1
+    _github_repo_name: notebook-operators
+  jupyter-ui:
+    charm: jupyter-ui
+    channel: 1.6/stable
+    scale: 1
+    _github_repo_name: notebook-operators
+  katib-controller:
+    charm: katib-controller
+    channel: 0.14/stable
+    scale: 1
+    _github_repo_name: katib-operators
+  katib-db:
+    charm: charmed-osm-mariadb-k8s
+    channel: latest/stable
+    scale: 1
+    options:
+      database: katib
+  katib-db-manager:
+    charm: katib-db-manager
+    channel: 0.14/stable
+    scale: 1
+    _github_repo_name: katib-operators
+  katib-ui:
+    charm: katib-ui
+    channel: 0.14/stable
+    scale: 1
+    _github_repo_name: katib-operators
+  kfp-api:
+    charm: kfp-api
+    channel: 2.0/stable
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-db:
+    charm: charmed-osm-mariadb-k8s
+    channel: latest/stable
+    scale: 1
+    options:
+      database: mlpipeline
+  kfp-persistence:
+    charm: kfp-persistence
+    channel: 2.0/stable
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-profile-controller:
+    charm: kfp-profile-controller
+    channel: 2.0/stable
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-schedwf:
+    charm: kfp-schedwf
+    channel: 2.0/stable
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-ui:
+    charm: kfp-ui
+    channel: 2.0/stable
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-viewer:
+    charm: kfp-viewer
+    channel: 2.0/stable
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-viz:
+    charm: kfp-viz
+    channel: 2.0/stable
+    scale: 1
+    _github_repo_name: kfp-operators
+  kubeflow-dashboard:
+    charm: kubeflow-dashboard
+    channel: 1.6/stable
+    scale: 1
+    _github_repo_name: kubeflow-dashboard-operator
+  kubeflow-profiles:
+    charm: kubeflow-profiles
+    channel: 1.6/stable
+    scale: 1
+    _github_repo_name: kubeflow-profiles-operator
+  kubeflow-roles:
+    charm: kubeflow-roles
+    channel: 1.6/stable
+    scale: 1
+    trust: true
+    _github_repo_name: kubeflow-roles-operator
+  kubeflow-volumes:
+    charm: kubeflow-volumes
+    channel: 1.6/stable
+    scale: 1
+    _github_repo_name: kubeflow-volumes-operator
+  metacontroller-operator:
+    charm: metacontroller-operator
+    channel: 2.0/stable
+    scale: 1
+    trust: true
+    _github_repo_name: metacontroller-operator
+  minio:
+    charm: minio
+    channel: ckf-1.6/stable
+    scale: 1
+    _github_repo_name: minio-operator
+  oidc-gatekeeper:
+    charm: oidc-gatekeeper
+    channel: ckf-1.6/stable
+    scale: 1
+    _github_repo_name: oidc-gatekeeper-operator
+  seldon-controller-manager:
+    charm: seldon-core
+    channel: 1.14/stable
+    scale: 1
+    _github_repo_name: seldon-core-operator
+  tensorboard-controller:
+    charm: tensorboard-controller
+    channel: 1.6/stable
+    scale: 1
+    _github_repo_name: kubeflow-tensorboards-operator
+  tensorboards-web-app:
+    charm: tensorboards-web-app
+    channel: 1.6/stable
+    scale: 1
+    _github_repo_name: kubeflow-tensorboards-operator
+  training-operator:
+    charm: training-operator
+    channel: 1.5/stable
+    scale: 1
+    trust: true
+    _github_repo_name: training-operator
+relations:
+  - [argo-controller, minio]
+  - [dex-auth:oidc-client, oidc-gatekeeper:oidc-client]
+  - [istio-pilot:ingress, dex-auth:ingress]
+  - [istio-pilot:ingress, jupyter-ui:ingress]
+  - [istio-pilot:ingress, katib-ui:ingress]
+  - [istio-pilot:ingress, kfp-ui:ingress]
+  - [istio-pilot:ingress, kubeflow-dashboard:ingress]
+  - [istio-pilot:ingress, kubeflow-volumes:ingress]
+  - [istio-pilot:ingress, oidc-gatekeeper:ingress]
+  - [istio-pilot:ingress-auth, oidc-gatekeeper:ingress-auth]
+  - [istio-pilot:istio-pilot, istio-ingressgateway:istio-pilot]
+  - [istio-pilot:ingress, tensorboards-web-app:ingress]
+  - [istio-pilot:gateway-info, tensorboard-controller:gateway-info]
+  - [katib-db-manager, katib-db]
+  - [kfp-api, kfp-db]
+  - [kfp-api:kfp-api, kfp-persistence:kfp-api]
+  - [kfp-api:kfp-api, kfp-ui:kfp-api]
+  - [kfp-api:kfp-viz, kfp-viz:kfp-viz]
+  - [kfp-api:object-storage, minio:object-storage]
+  - [kfp-profile-controller:object-storage, minio:object-storage]
+  - [kfp-ui:object-storage, minio:object-storage]
+  - [kubeflow-profiles, kubeflow-dashboard]

--- a/releases/1.6/stable/kubeflow/charmcraft.yaml
+++ b/releases/1.6/stable/kubeflow/charmcraft.yaml
@@ -1,0 +1,1 @@
+type: bundle


### PR DESCRIPTION
Adds stable 1.6 bundle definitions for kubeflow and kubeflow-lite. Please note this definitions expect all the charms in them to be uploaded in their <version>/stable channels.