### PR TITLE
add 1.7 edge and beta bundle definitions and define component versions

### DIFF
--- a/releases/1.7/beta/kubeflow/README.md
+++ b/releases/1.7/beta/kubeflow/README.md
@@ -1,0 +1,67 @@
+# Kubeflow Operators
+
+## Introduction
+
+Charmed Kubeflow is a full set of Kubernetes operators to deliver the 30+ applications and services
+that make up the latest version of Kubeflow, for easy operations anywhere, from workstations to
+on-prem, to public cloud and edge.
+
+A charm is a software package that includes an operator together with metadata that supports the
+integration of many operators in a coherent aggregated system.
+
+This technology leverages the Juju Operator Lifecycle Manager to provide day-0 to day-2 operations
+of Kubeflow.
+
+Visit [charmed-kubeflow.io][charmedkf] for more information.
+
+## Install
+
+
+For any Kubernetes, follow the [installation instructions][install].
+
+## Testing
+
+To deploy this bundle and run tests locally, do the following:
+
+1. Set up Kubernetes, Juju, and deploy the bundle you're interested in (`kubeflow` or
+   `kubeflow-lite`) using the [installation guide](https://charmed-kubeflow.io/docs/install/). This
+   must include populating the `.kube/config` file with your Kubernetes cluster as the active
+   context. Do not create a namespace with the same name as the username, this will cause 
+   pipelines tests to fail. Beware of using `admin` as the dex-auth static-username as the tests 
+   attempt to create a profile and `admin` conflicts with an existing default profile.
+1. Install test prerequisites:
+
+   ```bash
+   sudo snap install juju-wait --classic
+   sudo snap install juju-kubectl --classic
+   sudo snap install charmcraft --classic
+   sudo apt update
+   sudo apt install -y libssl-dev firefox-geckodriver
+   sudo pip3 install tox
+   sudo pip3 install -r requirements.txt
+   ```
+
+1. Run tests on your bundle with tox. As many tests need authentication, make sure you pass the
+   username and password you set in step (1) through environment variable or argument, for example:
+   - full bundle (using command line arguments):
+      ```
+      tox -e tests -- -m full --username user123@email.com --password user123
+      ```
+   - lite bundle (using environment variables):
+      ```
+      export KUBEFLOW_AUTH_USERNAME=user1234@email.com
+      export KUBEFLOW_AUTH_PASSWORD=user1234
+      tox -e tests -- -m lite
+      ```
+
+Subsets of the tests are also available using pytest's substring expression selector (e.g.:
+`tox -e tests -- -m full --username user123@email.com --password user123 -k 'selenium'` to run just
+the selenium tests).
+
+## Documentation
+
+Read the [official documentation][docs].
+
+[charmedkf]: https://charmed-kubeflow.io/
+[docs]: https://charmed-kubeflow.io/docs/
+[install]: https://charmed-kubeflow.io/docs/install

--- a/releases/1.7/beta/kubeflow/bundle.yaml
+++ b/releases/1.7/beta/kubeflow/bundle.yaml
@@ -1,0 +1,220 @@
+bundle: kubernetes
+name: kubeflow
+applications:
+  admission-webhook:
+    charm: admission-webhook
+    channel: 1.7/beta
+    scale: 1
+    _github_repo_name: admission-webhook-operator
+  argo-controller:
+    charm: argo-controller
+    channel: 3.3/beta
+    scale: 1
+    _github_repo_name: argo-operators
+  argo-server:
+    charm: argo-server
+    channel: 3.3/beta
+    scale: 1
+    _github_repo_name: argo-operators
+  dex-auth:
+    charm: dex-auth
+    channel: 2.31/beta
+    scale: 1
+    trust: true
+    _github_repo_name: dex-auth-operator
+  istio-ingressgateway:
+    charm: istio-gateway
+    channel: 1.16/beta
+    scale: 1
+    trust: true
+    _github_repo_name: istio-operators
+    options:
+      kind: ingress
+  istio-pilot:
+    charm: istio-pilot
+    channel: 1.16/beta
+    scale: 1
+    trust: true
+    _github_repo_name: istio-operators
+    options:
+      default-gateway: kubeflow-gateway
+  jupyter-controller:
+    charm: jupyter-controller
+    channel: 1.7/beta
+    scale: 1
+    _github_repo_name: notebook-operators
+  jupyter-ui:
+    charm: jupyter-ui
+    channel: 1.7/beta
+    scale: 1
+    trust: true
+    _github_repo_name: notebook-operators
+  katib-controller:
+    charm: katib-controller
+    channel: 0.15/beta
+    scale: 1
+    _github_repo_name: katib-operators
+  katib-db:
+    charm: charmed-osm-mariadb-k8s
+    channel: latest/stable
+    scale: 1
+    options:
+      database: katib
+  katib-db-manager:
+    charm: katib-db-manager
+    channel: 0.15/beta
+    scale: 1
+    _github_repo_name: katib-operators
+  katib-ui:
+    charm: katib-ui
+    channel: 0.15/beta
+    scale: 1
+    trust: true
+    _github_repo_name: katib-operators
+  kfp-api:
+    charm: kfp-api
+    channel: latest/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-db:
+    charm: charmed-osm-mariadb-k8s
+    channel: latest/stable
+    scale: 1
+    options:
+      database: mlpipeline
+  kfp-persistence:
+    charm: kfp-persistence
+    channel: latest/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-profile-controller:
+    charm: kfp-profile-controller
+    channel: latest/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-schedwf:
+    charm: kfp-schedwf
+    channel: latest/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-ui:
+    charm: kfp-ui
+    channel: latest/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-viewer:
+    charm: kfp-viewer
+    channel: latest/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-viz:
+    charm: kfp-viz
+    channel: latest/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  knative-eventing:
+    charm: knative-eventing
+    channel: latest/edge
+    scale: 1
+    _github_repo_name: knative-operators
+  knative-operator:
+    charm: knative-operator
+    channel: latest/edge
+    scale: 1
+    trust: true
+    _github_repo_name: knative-operators
+  knative-serving:
+    charm: knative-serving
+    channel: latest/edge
+    scale: 1
+    _github_repo_name: knative-operators
+  kserve-controller:
+    charm: kserve-controller
+    channel: 0.10/beta
+    scale: 1
+    trust: true
+    _github_repo_name: kserve-operators
+  kubeflow-dashboard:
+    charm: kubeflow-dashboard
+    channel: 1.7/beta
+    scale: 1
+    trust: true
+    _github_repo_name: kubeflow-dashboard-operator
+  kubeflow-profiles:
+    charm: kubeflow-profiles
+    channel: 1.7/beta
+    scale: 1
+    trust: true
+    _github_repo_name: kubeflow-profiles-operator
+  kubeflow-roles:
+    charm: kubeflow-roles
+    channel: 1.7/beta
+    scale: 1
+    trust: true
+    _github_repo_name: kubeflow-roles-operator
+  kubeflow-volumes:
+    charm: kubeflow-volumes
+    channel: 1.7/beta
+    scale: 1
+    _github_repo_name: kubeflow-volumes-operator
+  metacontroller-operator:
+    charm: metacontroller-operator
+    channel: 2.0/beta
+    scale: 1
+    trust: true
+    _github_repo_name: metacontroller-operator
+  minio:
+    charm: minio
+    channel: ckf-1.7/beta
+    scale: 1
+    _github_repo_name: minio-operator
+  oidc-gatekeeper:
+    charm: oidc-gatekeeper
+    channel: ckf-1.7/beta
+    scale: 1
+    _github_repo_name: oidc-gatekeeper-operator
+  seldon-controller-manager:
+    charm: seldon-core
+    channel: 1.15/beta
+    scale: 1
+    trust: true
+    _github_repo_name: seldon-core-operator
+  tensorboard-controller:
+    charm: tensorboard-controller
+    channel: 1.7/beta
+    scale: 1
+    _github_repo_name: kubeflow-tensorboards-operator
+  tensorboards-web-app:
+    charm: tensorboards-web-app
+    channel: 1.7/beta
+    scale: 1
+    _github_repo_name: kubeflow-tensorboards-operator
+  training-operator:
+    charm: training-operator
+    channel: 1.6/beta
+    scale: 1
+    trust: true
+    _github_repo_name: training-operator
+relations:
+  - [argo-controller, minio]
+  - [dex-auth:oidc-client, oidc-gatekeeper:oidc-client]
+  - [istio-pilot:ingress, dex-auth:ingress]
+  - [istio-pilot:ingress, jupyter-ui:ingress]
+  - [istio-pilot:ingress, katib-ui:ingress]
+  - [istio-pilot:ingress, kfp-ui:ingress]
+  - [istio-pilot:ingress, kubeflow-dashboard:ingress]
+  - [istio-pilot:ingress, kubeflow-volumes:ingress]
+  - [istio-pilot:ingress, oidc-gatekeeper:ingress]
+  - [istio-pilot:ingress-auth, oidc-gatekeeper:ingress-auth]
+  - [istio-pilot:istio-pilot, istio-ingressgateway:istio-pilot]
+  - [istio-pilot:ingress, tensorboards-web-app:ingress]
+  - [istio-pilot:gateway-info, tensorboard-controller:gateway-info]
+  - [katib-db-manager, katib-db]
+  - [kfp-api, kfp-db]
+  - [kfp-api:kfp-api, kfp-persistence:kfp-api]
+  - [kfp-api:kfp-api, kfp-ui:kfp-api]
+  - [kfp-api:kfp-viz, kfp-viz:kfp-viz]
+  - [kfp-api:object-storage, minio:object-storage]
+  - [kfp-profile-controller:object-storage, minio:object-storage]
+  - [kfp-ui:object-storage, minio:object-storage]
+  - [kubeflow-profiles, kubeflow-dashboard]

--- a/releases/1.7/beta/kubeflow/charmcraft.yaml
+++ b/releases/1.7/beta/kubeflow/charmcraft.yaml
@@ -1,0 +1,1 @@
+type: bundle

--- a/releases/1.7/edge/kubeflow/README.md
+++ b/releases/1.7/edge/kubeflow/README.md
@@ -1,0 +1,67 @@
+# Kubeflow Operators
+
+## Introduction
+
+Charmed Kubeflow is a full set of Kubernetes operators to deliver the 30+ applications and services
+that make up the latest version of Kubeflow, for easy operations anywhere, from workstations to
+on-prem, to public cloud and edge.
+
+A charm is a software package that includes an operator together with metadata that supports the
+integration of many operators in a coherent aggregated system.
+
+This technology leverages the Juju Operator Lifecycle Manager to provide day-0 to day-2 operations
+of Kubeflow.
+
+Visit [charmed-kubeflow.io][charmedkf] for more information.
+
+## Install
+
+
+For any Kubernetes, follow the [installation instructions][install].
+
+## Testing
+
+To deploy this bundle and run tests locally, do the following:
+
+1. Set up Kubernetes, Juju, and deploy the bundle you're interested in (`kubeflow` or
+   `kubeflow-lite`) using the [installation guide](https://charmed-kubeflow.io/docs/install/). This
+   must include populating the `.kube/config` file with your Kubernetes cluster as the active
+   context. Do not create a namespace with the same name as the username, this will cause 
+   pipelines tests to fail. Beware of using `admin` as the dex-auth static-username as the tests 
+   attempt to create a profile and `admin` conflicts with an existing default profile.
+1. Install test prerequisites:
+
+   ```bash
+   sudo snap install juju-wait --classic
+   sudo snap install juju-kubectl --classic
+   sudo snap install charmcraft --classic
+   sudo apt update
+   sudo apt install -y libssl-dev firefox-geckodriver
+   sudo pip3 install tox
+   sudo pip3 install -r requirements.txt
+   ```
+
+1. Run tests on your bundle with tox. As many tests need authentication, make sure you pass the
+   username and password you set in step (1) through environment variable or argument, for example:
+   - full bundle (using command line arguments):
+      ```
+      tox -e tests -- -m full --username user123@email.com --password user123
+      ```
+   - lite bundle (using environment variables):
+      ```
+      export KUBEFLOW_AUTH_USERNAME=user1234@email.com
+      export KUBEFLOW_AUTH_PASSWORD=user1234
+      tox -e tests -- -m lite
+      ```
+
+Subsets of the tests are also available using pytest's substring expression selector (e.g.:
+`tox -e tests -- -m full --username user123@email.com --password user123 -k 'selenium'` to run just
+the selenium tests).
+
+## Documentation
+
+Read the [official documentation][docs].
+
+[charmedkf]: https://charmed-kubeflow.io/
+[docs]: https://charmed-kubeflow.io/docs/
+[install]: https://charmed-kubeflow.io/docs/install

--- a/releases/1.7/edge/kubeflow/bundle.yaml
+++ b/releases/1.7/edge/kubeflow/bundle.yaml
@@ -1,0 +1,220 @@
+bundle: kubernetes
+name: kubeflow
+applications:
+  admission-webhook:
+    charm: admission-webhook
+    channel: 1.7/edge
+    scale: 1
+    _github_repo_name: admission-webhook-operator
+  argo-controller:
+    charm: argo-controller
+    channel: 3.3/edge
+    scale: 1
+    _github_repo_name: argo-operators
+  argo-server:
+    charm: argo-server
+    channel: 3.3/edge
+    scale: 1
+    _github_repo_name: argo-operators
+  dex-auth:
+    charm: dex-auth
+    channel: 2.31/edge
+    scale: 1
+    trust: true
+    _github_repo_name: dex-auth-operator
+  istio-ingressgateway:
+    charm: istio-gateway
+    channel: 1.16/edge
+    scale: 1
+    trust: true
+    _github_repo_name: istio-operators
+    options:
+      kind: ingress
+  istio-pilot:
+    charm: istio-pilot
+    channel: 1.16/edge
+    scale: 1
+    trust: true
+    _github_repo_name: istio-operators
+    options:
+      default-gateway: kubeflow-gateway
+  jupyter-controller:
+    charm: jupyter-controller
+    channel: 1.7/edge
+    scale: 1
+    _github_repo_name: notebook-operators
+  jupyter-ui:
+    charm: jupyter-ui
+    channel: 1.7/edge
+    scale: 1
+    trust: true
+    _github_repo_name: notebook-operators
+  katib-controller:
+    charm: katib-controller
+    channel: 0.15/edge
+    scale: 1
+    _github_repo_name: katib-operators
+  katib-db:
+    charm: charmed-osm-mariadb-k8s
+    channel: latest/stable
+    scale: 1
+    options:
+      database: katib
+  katib-db-manager:
+    charm: katib-db-manager
+    channel: 0.15/edge
+    scale: 1
+    _github_repo_name: katib-operators
+  katib-ui:
+    charm: katib-ui
+    channel: 0.15/edge
+    scale: 1
+    trust: true
+    _github_repo_name: katib-operators
+  kfp-api:
+    charm: kfp-api
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-db:
+    charm: charmed-osm-mariadb-k8s
+    channel: latest/stable
+    scale: 1
+    options:
+      database: mlpipeline
+  kfp-persistence:
+    charm: kfp-persistence
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-profile-controller:
+    charm: kfp-profile-controller
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-schedwf:
+    charm: kfp-schedwf
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-ui:
+    charm: kfp-ui
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-viewer:
+    charm: kfp-viewer
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-viz:
+    charm: kfp-viz
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  knative-eventing:
+    charm: knative-eventing
+    channel: 1.8/edge
+    scale: 1
+    _github_repo_name: knative-operators
+  knative-operator:
+    charm: knative-operator
+    channel: 1.8/edge
+    scale: 1
+    trust: true
+    _github_repo_name: knative-operators
+  knative-serving:
+    charm: knative-serving
+    channel: 1.8/edge
+    scale: 1
+    _github_repo_name: knative-operators
+  kserve-controller:
+    charm: kserve-controller
+    channel: 0.10/edge
+    scale: 1
+    trust: true
+    _github_repo_name: kserve-operators
+  kubeflow-dashboard:
+    charm: kubeflow-dashboard
+    channel: 1.7/edge
+    scale: 1
+    trust: true
+    _github_repo_name: kubeflow-dashboard-operator
+  kubeflow-profiles:
+    charm: kubeflow-profiles
+    channel: 1.7/edge
+    scale: 1
+    trust: true
+    _github_repo_name: kubeflow-profiles-operator
+  kubeflow-roles:
+    charm: kubeflow-roles
+    channel: 1.7/edge
+    scale: 1
+    trust: true
+    _github_repo_name: kubeflow-roles-operator
+  kubeflow-volumes:
+    charm: kubeflow-volumes
+    channel: 1.7/edge
+    scale: 1
+    _github_repo_name: kubeflow-volumes-operator
+  metacontroller-operator:
+    charm: metacontroller-operator
+    channel: 2.0/edge
+    scale: 1
+    trust: true
+    _github_repo_name: metacontroller-operator
+  minio:
+    charm: minio
+    channel: ckf-1.7/edge
+    scale: 1
+    _github_repo_name: minio-operator
+  oidc-gatekeeper:
+    charm: oidc-gatekeeper
+    channel: ckf-1.7/edge
+    scale: 1
+    _github_repo_name: oidc-gatekeeper-operator
+  seldon-controller-manager:
+    charm: seldon-core
+    channel: 1.15/edge
+    scale: 1
+    trust: true
+    _github_repo_name: seldon-core-operator
+  tensorboard-controller:
+    charm: tensorboard-controller
+    channel: 1.7/edge
+    scale: 1
+    _github_repo_name: kubeflow-tensorboards-operator
+  tensorboards-web-app:
+    charm: tensorboards-web-app
+    channel: 1.7/edge
+    scale: 1
+    _github_repo_name: kubeflow-tensorboards-operator
+  training-operator:
+    charm: training-operator
+    channel: 1.6/edge
+    scale: 1
+    trust: true
+    _github_repo_name: training-operator
+relations:
+  - [argo-controller, minio]
+  - [dex-auth:oidc-client, oidc-gatekeeper:oidc-client]
+  - [istio-pilot:ingress, dex-auth:ingress]
+  - [istio-pilot:ingress, jupyter-ui:ingress]
+  - [istio-pilot:ingress, katib-ui:ingress]
+  - [istio-pilot:ingress, kfp-ui:ingress]
+  - [istio-pilot:ingress, kubeflow-dashboard:ingress]
+  - [istio-pilot:ingress, kubeflow-volumes:ingress]
+  - [istio-pilot:ingress, oidc-gatekeeper:ingress]
+  - [istio-pilot:ingress-auth, oidc-gatekeeper:ingress-auth]
+  - [istio-pilot:istio-pilot, istio-ingressgateway:istio-pilot]
+  - [istio-pilot:ingress, tensorboards-web-app:ingress]
+  - [istio-pilot:gateway-info, tensorboard-controller:gateway-info]
+  - [katib-db-manager, katib-db]
+  - [kfp-api, kfp-db]
+  - [kfp-api:kfp-api, kfp-persistence:kfp-api]
+  - [kfp-api:kfp-api, kfp-ui:kfp-api]
+  - [kfp-api:kfp-viz, kfp-viz:kfp-viz]
+  - [kfp-api:object-storage, minio:object-storage]
+  - [kfp-profile-controller:object-storage, minio:object-storage]
+  - [kfp-ui:object-storage, minio:object-storage]
+  - [kubeflow-profiles, kubeflow-dashboard]

--- a/releases/1.7/edge/kubeflow/charmcraft.yaml
+++ b/releases/1.7/edge/kubeflow/charmcraft.yaml
@@ -1,0 +1,1 @@
+type: bundle


### PR DESCRIPTION
Create edge and beta bundle files with upgraded components versions for 1.7 release. Please note this PR is adding the full bundle, as kubeflow-lite may be removed in this release.

> NOTE: unchecked items are the ones whose version is still under discussion/missing, and thus it hasn't been updated in the bundles definition. Mark the item ONLY after modifying the bundle files.

The following versions are extracted from kubeflow/manifests#2359:

#### Kubeflow dependencies

- [x] kubernetes 1.24/1.25 
- [x] istio-operators 1.16
- [x] knative 1.8.1 - to be added to bundle 1.7
- [x] dex-auth-operator 2.31
- [x] argo-operators 3.3 ([3.3.8](https://github.com/argoproj/argo-workflows/releases/tag/v3.3.8))

#### Kubeflow projects

- [x] training-operator 1.6 ([1.6.0-rc0 release](https://github.com/kubeflow/training-operator/releases/tag/v1.6.0-rc.0))
- [x] katib 0.15 ([0.15.0 release](https://github.com/kubeflow/katib/releases/tag/v0.15.0-rc.0))
- [x] notebook-operators 1.7
- [x] kubeflow-dashboard-operator 1.7
- [x] kubeflow-profiles-operator 1.7
- [x] kubeflow-tensorboard-operators 1.7
- [x] kubeflow-volumes-operator 1.7
- [x] kubeflow-roles-operator 1.7
- [x] kfp-operators ~v2.0-alpha.6
- [x] admission-webhook-operator 1.7
- [x] kserve-operators 0.10 -> to be added to bundle

The following versions are either extracted from the upstream project or decided by the Charmed Kubeflow team:

#### Charmed Kubeflow specific

- [x] minio (no change) - ckf-1.7
- [x] oidc-gatekeeper - ckf-1.7 (e236439, see kubeflow/manifests#2386 for more information)
- [x] katib-db points to charmed-osm-mariadb-k8s - stays the same
- [x] kfp-db points to charmed-osm-mariadb-k8s - stays the same
- [x] metacontroller-operator (stays the same)
- [x] seldon-core-operator v1.15

#### Discussion

1. Should we add knative and kserve in the kubeflow-bundle?
2. Is kubeflow-lite still a thing for 1.7?
3. Seldon v2 is out, should we make the big jump? - Not for now
4. Should we stop maintiaining mlmd, metacontroller-operator?

#### Useful links
- kubeflow/manifests#2359
- Kubernetes deprecation [guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/)