### PR TITLE
Test migration from MariaDB to new MySQL-K8s

### DIFF
--- a/releases/1.6/edge/kubeflow/bundle.yaml
+++ b/releases/1.6/edge/kubeflow/bundle.yaml
@@ -54,11 +54,13 @@ applications:
     scale: 1
     _github_repo_name: katib-operators
   katib-db:
-    charm: charmed-osm-mariadb-k8s
-    channel: latest/stable
+    charm: mysql-k8s
+    channel: latest/edge
+    series: jammy
     scale: 1
     options:
-      database: katib
+      mysql-interface-database: katib
+      mysql-interface-user: mysql
   katib-db-manager:
     charm: katib-db-manager
     channel: 0.14/edge
@@ -75,11 +77,13 @@ applications:
     scale: 1
     _github_repo_name: kfp-operators
   kfp-db:
-    charm: charmed-osm-mariadb-k8s
-    channel: latest/stable
+    charm: mysql-k8s
+    channel: latest/edge
+    series: jammy
     scale: 1
     options:
-      database: mlpipeline
+      mysql-interface-database: mlpipeline
+      mysql-interface-user: mysql
   kfp-persistence:
     charm: kfp-persistence
     channel: 2.0/edge
@@ -182,8 +186,8 @@ relations:
   - [istio-pilot:istio-pilot, istio-ingressgateway:istio-pilot]
   - [istio-pilot:ingress, tensorboards-web-app:ingress]
   - [istio-pilot:gateway-info, tensorboard-controller:gateway-info]
-  - [katib-db-manager, katib-db]
-  - [kfp-api, kfp-db]
+  - [katib-db-manager:mysql, katib-db:mysql]
+  - [kfp-api:mysql, kfp-db:mysql]
   - [kfp-api:kfp-api, kfp-persistence:kfp-api]
   - [kfp-api:kfp-api, kfp-ui:kfp-api]
   - [kfp-api:kfp-viz, kfp-viz:kfp-viz]


### PR DESCRIPTION
The new charm https://charmhub.io/mysql-k8s has been developed by Canonical Data Platform team.

The new charm supports both:
 * legacy 'mysql' interface
 * new 'mysql-client' interface

The PR is just to demonstrate the simplicity of migration from `charmed-osm-mariadb-k8s` to `mysql-k8s`.

The channel `latest/edge` cannot be used in production! The `latest/beta` and `latest/candidate` will be published soonish. Consider this PR as demo only!!!

Please note, the `series: jammy` is necessary as Kubeflow is pinned to old Juju version '2.9.34' which doesn't work well with charms being published for several series, like 'focal+jammy' (charm container is launched from focal but db container is from jammy). It is not reproducible on modern versions of juju in 2.9 branch.