### PR TITLE
fix: add trust to knative-eventing and knative-serving

### DIFF
--- a/releases/1.7/beta/kubeflow/bundle.yaml
+++ b/releases/1.7/beta/kubeflow/bundle.yaml
@@ -116,6 +116,7 @@ applications:
     charm: knative-eventing
     channel: latest/edge
     scale: 1
+    trust: true
     options:
       namespace: knative-eventing
     _github_repo_name: knative-operators
@@ -129,6 +130,7 @@ applications:
     charm: knative-serving
     channel: latest/edge
     scale: 1
+    trust: true
     options:
       namespace: knative-serving
       istio.gateway.namespace: kubeflow

--- a/releases/1.7/edge/kubeflow/bundle.yaml
+++ b/releases/1.7/edge/kubeflow/bundle.yaml
@@ -116,6 +116,7 @@ applications:
     charm: knative-eventing
     channel: 1.8/edge
     scale: 1
+    trust: true
     options:
       namespace: knative-eventing
     _github_repo_name: knative-operators
@@ -129,6 +130,7 @@ applications:
     charm: knative-serving
     channel: 1.8/edge
     scale: 1
+    trust: true
     options:
       namespace: knative-serving
       istio.gateway.namespace: kubeflow


### PR DESCRIPTION
update bundle definition in 1.7/beta and 1.7/edge with missing `trust: true` for `knative-eventing` and `knative-serving` charms.