### PR TITLE
feat: add overlay for a microk8s based single-user install

### DIFF
--- a/overlays/microk8s-single-user-overlay.yaml
+++ b/overlays/microk8s-single-user-overlay.yaml
@@ -1,0 +1,10 @@
+description: Bundle overlay to configure Kubeflow for a single default user on Microk8s
+applications:
+  dex-auth:
+    options:
+      public-url: http://10.64.140.43.nip.io
+      static-username: kubeflow
+      static-password: kubeflow
+  oidc-gatekeeper:
+    options:
+      public-url: http://10.64.140.43.nip.io

--- a/overlays/microk8s-single-user-overlay.yaml
+++ b/overlays/microk8s-single-user-overlay.yaml
@@ -3,8 +3,8 @@ applications:
   dex-auth:
     options:
       public-url: http://10.64.140.43.nip.io
-      static-username: kubeflow
-      static-password: kubeflow
+      static-username: kubeflow-user
+      static-password: kubeflow-user
   oidc-gatekeeper:
     options:
       public-url: http://10.64.140.43.nip.io


### PR DESCRIPTION
This adds an overlay that configures Kubeflow's dex-auth and oidc-gateway charms with default settings applicable to a single-user install using microk8s based our [tutorial](https://charmed-kubeflow.io/docs/get-started-with-charmed-kubeflow#heading--install-and-prepare-microk8s-).  The purpose of this overlay is to provide a simplified first time install experience without damaging the flexibility of the general Kubeflow bundle.  Without this overlay, our guides tell users to do:

```
juju deploy kubeflow --trust
juju config dex-auth public-url=http://10.64.140.43.nip.io
juju config oidc-gatekeeper public-url=http://10.64.140.43.nip.io
juju config dex-auth static-username=kubeflow
juju config dex-auth static-password=kubeflow
```

whereas with this overlay, we can simplify this to:

```
wget https://raw.githubusercontent.com/canonical/bundle-kubeflow/main/overlays/microk8s-single-user-overlay.yaml
juju deploy kubeflow --trust --overlay microk8s-single-user-overlay.yaml
```