### PR TITLE
Changes in bundle.yaml 

### DIFF
--- a/releases/latest/edge/bundle.yaml
+++ b/releases/latest/edge/bundle.yaml
@@ -3,28 +3,28 @@ name: kubeflow
 applications:
   admission-webhook:
     charm: admission-webhook
-    channel: 1.7/edge
+    channel: latest/edge
     scale: 1
     _github_repo_name: admission-webhook-operator
   argo-controller:
     charm: argo-controller
-    channel: 3.3/edge
+    channel: latest/edge
     scale: 1
     _github_repo_name: argo-operators
   argo-server:
     charm: argo-server
-    channel: 3.3/edge
+    channel: latest/edge
     scale: 1
     _github_repo_name: argo-operators
   dex-auth:
     charm: dex-auth
-    channel: 2.31/edge
+    channel: latest/edge
     scale: 1
     trust: true
     _github_repo_name: dex-auth-operator
   istio-ingressgateway:
     charm: istio-gateway
-    channel: 1.16/edge
+    channel: latest/edge
     scale: 1
     trust: true
     _github_repo_name: istio-operators
@@ -32,7 +32,7 @@ applications:
       kind: ingress
   istio-pilot:
     charm: istio-pilot
-    channel: 1.16/edge
+    channel: latest/edge
     scale: 1
     trust: true
     _github_repo_name: istio-operators
@@ -40,77 +40,77 @@ applications:
       default-gateway: kubeflow-gateway
   jupyter-controller:
     charm: jupyter-controller
-    channel: 1.7/edge
+    channel: latest/edge
     scale: 1
     _github_repo_name: notebook-operators
   jupyter-ui:
     charm: jupyter-ui
-    channel: 1.7/edge
+    channel: latest/edge
     scale: 1
     trust: true
     _github_repo_name: notebook-operators
   katib-controller:
     charm: katib-controller
-    channel: 0.15/edge
+    channel: latest/edge
     scale: 1
     _github_repo_name: katib-operators
   katib-db:
     charm: mysql-k8s
-    channel: 8.0/stable
+    channel: latest/stable
     scale: 1
   katib-db-manager:
     charm: katib-db-manager
-    channel: 0.15/edge
+    channel: latest/edge
     scale: 1
     _github_repo_name: katib-operators
   katib-ui:
     charm: katib-ui
-    channel: 0.15/edge
+    channel: latest/edge
     scale: 1
     trust: true
     _github_repo_name: katib-operators
   kfp-api:
     charm: kfp-api
-    channel: 2.0/edge
+    channel: latest/edge
     scale: 1
     _github_repo_name: kfp-operators
   kfp-db:
     charm: mysql-k8s
-    channel: 8.0/stable
+    channel: latest/stable
     scale: 1
   kfp-persistence:
     charm: kfp-persistence
-    channel: 2.0/edge
+    channel: latest/edge
     scale: 1
     _github_repo_name: kfp-operators
   kfp-profile-controller:
     charm: kfp-profile-controller
-    channel: 2.0/edge
+    channel: latest/edge
     scale: 1
     _github_repo_name: kfp-operators
   kfp-schedwf:
     charm: kfp-schedwf
-    channel: 2.0/edge
+    channel: latest/edge
     scale: 1
     _github_repo_name: kfp-operators
   kfp-ui:
     charm: kfp-ui
-    channel: 2.0/edge
+    channel: latest/edge
     scale: 1
     _github_repo_name: kfp-operators
   kfp-viewer:
     charm: kfp-viewer
-    channel: 2.0/edge
+    channel: latest/edge
     scale: 1
     _github_repo_name: kfp-operators
   kfp-viz:
     charm: kfp-viz
-    channel: 2.0/edge
+    channel: latest/edge
     scale: 1
     _github_repo_name: kfp-operators
   knative-eventing:
     charm: knative-eventing
-    channel: 1.8/edge
+    channel: latest/edge
     scale: 1
     trust: true
     options:
@@ -118,13 +118,13 @@ applications:
     _github_repo_name: knative-operators
   knative-operator:
     charm: knative-operator
-    channel: 1.8/edge
+    channel: latest/edge
     scale: 1
     trust: true
     _github_repo_name: knative-operators
   knative-serving:
     charm: knative-serving
-    channel: 1.8/edge
+    channel: latest/edge
     scale: 1
     trust: true
     options:
@@ -134,68 +134,68 @@ applications:
     _github_repo_name: knative-operators
   kserve-controller:
     charm: kserve-controller
-    channel: 0.10/edge
+    channel: latest/edge
     scale: 1
     trust: true
     _github_repo_name: kserve-operators
   kubeflow-dashboard:
     charm: kubeflow-dashboard
-    channel: 1.7/edge
+    channel: latest/edge
     scale: 1
     trust: true
     _github_repo_name: kubeflow-dashboard-operator
   kubeflow-profiles:
     charm: kubeflow-profiles
-    channel: 1.7/edge
+    channel: latest/edge
     scale: 1
     trust: true
     _github_repo_name: kubeflow-profiles-operator
   kubeflow-roles:
     charm: kubeflow-roles
-    channel: 1.7/edge
+    channel: latest/edge
     scale: 1
     trust: true
     _github_repo_name: kubeflow-roles-operator
   kubeflow-volumes:
     charm: kubeflow-volumes
-    channel: 1.7/edge
+    channel: latest/edge
     scale: 1
     _github_repo_name: kubeflow-volumes-operator
   metacontroller-operator:
     charm: metacontroller-operator
-    channel: 2.0/edge
+    channel: latest/edge
     scale: 1
     trust: true
     _github_repo_name: metacontroller-operator
   minio:
     charm: minio
-    channel: ckf-1.7/edge
+    channel: latest/edge
     scale: 1
     _github_repo_name: minio-operator
   oidc-gatekeeper:
     charm: oidc-gatekeeper
-    channel: ckf-1.7/edge
+    channel: latest/edge
     scale: 1
     _github_repo_name: oidc-gatekeeper-operator
   seldon-controller-manager:
     charm: seldon-core
-    channel: 1.15/edge
+    channel: latest/edge
     scale: 1
     trust: true
     _github_repo_name: seldon-core-operator
   tensorboard-controller:
     charm: tensorboard-controller
-    channel: 1.7/edge
+    channel: latest/edge
     scale: 1
     _github_repo_name: kubeflow-tensorboards-operator
   tensorboards-web-app:
     charm: tensorboards-web-app
-    channel: 1.7/edge
+    channel: latest/edge
     scale: 1
     _github_repo_name: kubeflow-tensorboards-operator
   training-operator:
     charm: training-operator
-    channel: 1.6/edge
+    channel: latest/edge
     scale: 1
     trust: true
     _github_repo_name: training-operator

--- a/releases/latest/edge/bundle.yaml
+++ b/releases/latest/edge/bundle.yaml
@@ -56,7 +56,7 @@ applications:
     _github_repo_name: katib-operators
   katib-db:
     charm: mysql-k8s
-    channel: latest/stable
+    channel: 8.0/stable
     scale: 1
   katib-db-manager:
     charm: katib-db-manager
@@ -76,7 +76,7 @@ applications:
     _github_repo_name: kfp-operators
   kfp-db:
     charm: mysql-k8s
-    channel: latest/stable
+    channel: 8.0/stable
     scale: 1
   kfp-persistence:
     charm: kfp-persistence

--- a/releases/latest/edge/bundle.yaml
+++ b/releases/latest/edge/bundle.yaml
@@ -137,6 +137,8 @@ applications:
     channel: latest/edge
     scale: 1
     trust: true
+    options:
+      deployment-mode: serverless
     _github_repo_name: kserve-operators
   kubeflow-dashboard:
     charm: kubeflow-dashboard
@@ -221,4 +223,6 @@ relations:
   - [kfp-api:object-storage, minio:object-storage]
   - [kfp-profile-controller:object-storage, minio:object-storage]
   - [kfp-ui:object-storage, minio:object-storage]
+  - [kserve-controller:ingress-gateway, istio-pilot:gateway-info]
+  - [kserve-controller:local-gateway, knative-serving:local-gateway]
   - [kubeflow-profiles, kubeflow-dashboard]


### PR DESCRIPTION
This PR:
* points all charms to latest/edge to reflect the real latest/edge bundle
* configure kserve in serverless mode with charm configurations and relations