### PR TITLE
Automatically add user profile during bundle tests

### DIFF
--- a/tests-bundle/1.7/test_1dot7.py
+++ b/tests-bundle/1.7/test_1dot7.py
@@ -103,6 +103,13 @@ async def test_deploy(ops_test: OpsTest, lightkube_client, deploy_cmd):
         idle_period=from_minutes(minutes=3),
     )
 
+
+@pytest.mark.xfail
+def test_profile_creation_action(ops_test: OpsTest):
+    """Test that the create-profile action works.
+
+    Also, this will allow to test selenium and skip welcome page in dashboard UI.
+    """
     await ops_test.model.applications["kubeflow-profiles"].units[0].run_action(
-        "create-profile", profilename="demo-namespace", username=USERNAME
+        "create-profile", profilename=f"{USERNAME}@email.com", username=USERNAME
     )

--- a/tests-bundle/1.7/test_1dot7.py
+++ b/tests-bundle/1.7/test_1dot7.py
@@ -104,7 +104,7 @@ async def test_deploy(ops_test: OpsTest, lightkube_client, deploy_cmd):
     )
 
 
-@pytest.mark.xfail
+@pytest.mark.abort_on_fail
 def test_profile_creation_action(ops_test: OpsTest):
     """Test that the create-profile action works.
 

--- a/tests-bundle/1.7/test_1dot7.py
+++ b/tests-bundle/1.7/test_1dot7.py
@@ -102,3 +102,7 @@ async def test_deploy(ops_test: OpsTest, lightkube_client, deploy_cmd):
         timeout=from_minutes(minutes=30),
         idle_period=from_minutes(minutes=3),
     )
+
+    await ops_test.model.applications["kubeflow-profiles"].units[0].run_action(
+        "create-profile", profilename="demo-namespace", username=USERNAME
+    )

--- a/tests-bundle/1.7/test_tutorial.py
+++ b/tests-bundle/1.7/test_tutorial.py
@@ -23,6 +23,10 @@ class TestGetStartedTutorial:
     For code see advanced_notebook.py.tmpl file.
 
     Once notebook is executed, we will check that all 5 Epochs are completed.
+
+    Prerequisites for the test:
+        - Full bundle is deployed
+        - User namespace is created (in order to skip welcome page)
     """
 
     @pytest.mark.selenium

--- a/tests-bundle/1.7/test_tutorial.py
+++ b/tests-bundle/1.7/test_tutorial.py
@@ -24,6 +24,7 @@ class TestGetStartedTutorial:
 
     Once notebook is executed, we will check that all 5 Epochs are completed.
     """
+
     @pytest.mark.selenium
     def test_create_notebook(self, driver):
         # this test relies on the name ordering to be executed after deployment


### PR DESCRIPTION
Description: Adds invocation of the the kubeflow-profiles `create-profile` action to automatically create a user `Profile` during testing so that we do not get prompted with the first-time-login box to create a user in the dashboard