### PR TITLE
Update 1.7/stable/beta bundle definitions for 1.7 Patch 1

### DIFF
--- a/releases/1.7/beta/kubeflow/bundle.yaml
+++ b/releases/1.7/beta/kubeflow/bundle.yaml
@@ -55,15 +55,16 @@ applications:
     scale: 1
     _github_repo_name: katib-operators
   katib-db:
-    charm: charmed-osm-mariadb-k8s
-    channel: latest/stable
+    charm: mysql-k8s
+    channel: 8.0/stable
     scale: 1
-    options:
-      database: katib
+    trust: true
+    constraints: mem=2G
   katib-db-manager:
     charm: katib-db-manager
     channel: 0.15/beta
     scale: 1
+    trust: true
     _github_repo_name: katib-operators
   katib-ui:
     charm: katib-ui
@@ -75,13 +76,14 @@ applications:
     charm: kfp-api
     channel: 2.0/beta
     scale: 1
+    trust: true
     _github_repo_name: kfp-operators
   kfp-db:
-    charm: charmed-osm-mariadb-k8s
-    channel: latest/stable
+    charm: mysql-k8s
+    channel: 8.0/stable
     scale: 1
-    options:
-      database: mlpipeline
+    trust: true
+    constraints: mem=2G
   kfp-persistence:
     charm: kfp-persistence
     channel: 2.0/beta
@@ -217,8 +219,9 @@ relations:
   - [istio-pilot:istio-pilot, istio-ingressgateway:istio-pilot]
   - [istio-pilot:ingress, tensorboards-web-app:ingress]
   - [istio-pilot:gateway-info, tensorboard-controller:gateway-info]
-  - [katib-db-manager, katib-db]
-  - [kfp-api, kfp-db]
+  - [istio-pilot:gateway-info, kserve-controller:ingress-gateway]
+  - [katib-db-manager:relational-db, katib-db:database]
+  - [kfp-api:relational-db, kfp-db:database]
   - [kfp-api:kfp-api, kfp-persistence:kfp-api]
   - [kfp-api:kfp-api, kfp-ui:kfp-api]
   - [kfp-api:kfp-viz, kfp-viz:kfp-viz]

--- a/releases/1.7/stable/kubeflow/bundle.yaml
+++ b/releases/1.7/stable/kubeflow/bundle.yaml
@@ -55,15 +55,16 @@ applications:
     scale: 1
     _github_repo_name: katib-operators
   katib-db:
-    charm: charmed-osm-mariadb-k8s
-    channel: latest/stable
+    charm: mysql-k8s
+    channel: 8.0/stable
     scale: 1
-    options:
-      database: katib
+    trust: true
+    constraints: mem=2G
   katib-db-manager:
     charm: katib-db-manager
     channel: 0.15/stable
     scale: 1
+    trust: true
     _github_repo_name: katib-operators
   katib-ui:
     charm: katib-ui
@@ -75,13 +76,14 @@ applications:
     charm: kfp-api
     channel: 2.0/stable
     scale: 1
+    trust: true
     _github_repo_name: kfp-operators
   kfp-db:
-    charm: charmed-osm-mariadb-k8s
-    channel: latest/stable
+    charm: mysql-k8s
+    channel: 8.0/stable
     scale: 1
-    options:
-      database: mlpipeline
+    trust: true
+    constraints: mem=2G
   kfp-persistence:
     charm: kfp-persistence
     channel: 2.0/stable
@@ -217,8 +219,9 @@ relations:
   - [istio-pilot:istio-pilot, istio-ingressgateway:istio-pilot]
   - [istio-pilot:ingress, tensorboards-web-app:ingress]
   - [istio-pilot:gateway-info, tensorboard-controller:gateway-info]
-  - [katib-db-manager, katib-db]
-  - [kfp-api, kfp-db]
+  - [istio-pilot:gateway-info, kserve-controller:ingress-gateway]
+  - [katib-db-manager:relational-db, katib-db:database]
+  - [kfp-api:relational-db, kfp-db:database]
   - [kfp-api:kfp-api, kfp-persistence:kfp-api]
   - [kfp-api:kfp-api, kfp-ui:kfp-api]
   - [kfp-api:kfp-viz, kfp-viz:kfp-viz]


### PR DESCRIPTION
## Updates to bundle definition from 1.7 to 1.7 Patch 1

* Deploy KFP API with trust
  * Mandatory since [charm rewrite](https://github.com/canonical/kfp-operators/commit/58615a72a11fbac5fafad1796b04fcb1a7be1c31) following the sidecar pattern 
* Deploy Katib DB manager with trust
  * Mandatory since [charm rewrite](https://github.com/canonical/kfp-operators/commit/58615a72a11fbac5fafad1796b04fcb1a7be1c31) following the sidecar pattern 
* Integrate KFP API charm with MySQL
  * Use the `relational-db` relation instead of the default `mysql` 
  * https://github.com/canonical/kfp-operators/issues/201
* Integrate Katib DB manager with MySQL
  * Use the `relational-db` relation instead of the default `mysql` 
  * https://github.com/canonical/katib-operators/issues/74
* Integrate KServe with Istio 