### PR TITLE
fix: Update 1.7/edge bundle

### DIFF
--- a/releases/1.7/edge/kubeflow/bundle.yaml
+++ b/releases/1.7/edge/kubeflow/bundle.yaml
@@ -56,7 +56,7 @@ applications:
     _github_repo_name: katib-operators
   katib-db:
     charm: mysql-k8s
-    channel: 8.0/stable
+    channel: 8.0/edge
     scale: 1
     trust: true
     constraints: mem=2G
@@ -80,7 +80,7 @@ applications:
     _github_repo_name: kfp-operators
   kfp-db:
     charm: mysql-k8s
-    channel: 8.0/stable
+    channel: 8.0/edge
     scale: 1
     trust: true
     constraints: mem=2G


### PR DESCRIPTION
Update 1.7/edge to use `edge` channel for `mysql-k8s` charms, since there is a known issue on `stable`. See canonical/mysql-k8s-operator#239. Note that this change should not be promoted to stable.

Signed-off-by: Orfeas Kourkakis <orfeas@arrikto.com>