### PR TITLE
updated latest/edge bundle.yaml to use dashboard links

### DIFF
--- a/releases/latest/edge/bundle.yaml
+++ b/releases/latest/edge/bundle.yaml
@@ -235,3 +235,8 @@ relations:
   - [kserve-controller:ingress-gateway, istio-pilot:gateway-info]
   - [kserve-controller:local-gateway, knative-serving:local-gateway]
   - [kubeflow-profiles, kubeflow-dashboard]
+  - [kubeflow-dashboard:links, jupyter-ui:dashboard-links]
+  - [kubeflow-dashboard:links, katib-ui:dashboard-links]
+  - [kubeflow-dashboard:links, kfp-ui:dashboard-links]
+  - [kubeflow-dashboard:links, kubeflow-volumes:dashboard-links]
+  - [kubeflow-dashboard:links, tensorboards-web-app:dashboard-links]


### PR DESCRIPTION
This adds the dashboard links relations to the bundle, as required by the implementation of the [dynamic dashboard PR](https://github.com/canonical/kubeflow-dashboard-operator/pull/134)