### PR TITLE
ci: Deploy and test CKF to EKS cluster fixup

### DIFF
--- a/.github/workflows/deploy-eks.yaml
+++ b/.github/workflows/deploy-eks.yaml
@@ -7,7 +7,7 @@ on:
       BUNDLE_KUBEFLOW_EKS_AWS_SECRET_ACCESS_KEY:
         required: true
   schedule:
-    - cron: "0 0 * * 2"
+    - cron: "23 0 * * 2"
 jobs:
   deploy-ckf-to-eks:
     runs-on: ubuntu-22.04

--- a/tests/integration/test_bundle_deployment.py
+++ b/tests/integration/test_bundle_deployment.py
@@ -38,8 +38,8 @@ class TestCharm:
         )
 
         url = get_public_url(lightkube_client, BUNDLE_NAME)
-        subprocess.Popen(["juju", "config", "dex-auth", f"public-url={url}"])
-        subprocess.Popen(["juju", "config", "oidc-gatekeeper", f"public-url={url}"])
+        await ops_test.model.applications["dex-auth"].set_config({"public-url": url})
+        await ops_test.model.applications["oidc-gatekeeper"].set_config({"public-url": url})
 
         await ops_test.model.wait_for_idle(
             status="active",


### PR DESCRIPTION
This is small fixup to https://github.com/canonical/bundle-kubeflow/pull/635. In more detail, this PR:
* ci: Run action at 0:23 instead of 0:00 since Github has reported issues with Github actions being queued longer because everyone schedules their actions at the beginning of an hour.
* tests: Use Ops framework instead of `subprocess.Popen()` in order to configure applications.
