### PR TITLE
Update latest/edge to trust tensorboards-operator charms

### DIFF
--- a/releases/latest/edge/bundle.yaml
+++ b/releases/latest/edge/bundle.yaml
@@ -198,11 +198,13 @@ applications:
     charm: tensorboard-controller
     channel: latest/edge
     scale: 1
+    trust: true
     _github_repo_name: kubeflow-tensorboards-operator
   tensorboards-web-app:
     charm: tensorboards-web-app
     channel: latest/edge
     scale: 1
+    trust: true
     _github_repo_name: kubeflow-tensorboards-operator
   training-operator:
     charm: training-operator


### PR DESCRIPTION
Add `trust: true` to tensorboard-controller and tensorboards-web-app charms since they are now following the sidecar pattern using Pebble.