### PR TITLE
fix: save space

### DIFF
--- a/.github/workflows/scan-images.yaml
+++ b/.github/workflows/scan-images.yaml
@@ -10,10 +10,23 @@ jobs:
     name: Scan images in bundle
     strategy:
       matrix:
-        release: [ 1.7, 1.6 ]
+        release: [ 1.7 ]
         risk: [ stable ]
     runs-on: ubuntu-20.04
     steps:
+      # Ideally we'd use self-hosted runners, but this effort is still not stable
+      # This action will remove unused software (dotnet, haskell, android libs, codeql,
+      # and docker images) from the GH runner, which will liberate around 60 GB of storage
+      # distributed in 40GB for root and around 20 for a mnt point.
+      - name: Maximise GH runner space
+        uses: easimon/maximize-build-space@v7
+        with:
+          root-reserve-mb: 40960
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
+          remove-android: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
       - name: Checkout
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
GH runners are running out of space. Need to add cleanup actions to save space.
Summary of changes:
- Added space saving step to workflow.
- Removed 1.6 from scan.