### PR TITLE
latest/edge: Trust kfp charms rewritten with sidecar

### DIFF
--- a/releases/latest/edge/bundle.yaml
+++ b/releases/latest/edge/bundle.yaml
@@ -91,26 +91,31 @@ applications:
     charm: kfp-persistence
     channel: latest/edge
     scale: 1
+    trust: true
     _github_repo_name: kfp-operators
   kfp-profile-controller:
     charm: kfp-profile-controller
     channel: latest/edge
     scale: 1
+    trust: true
     _github_repo_name: kfp-operators
   kfp-schedwf:
     charm: kfp-schedwf
     channel: latest/edge
     scale: 1
+    trust: true
     _github_repo_name: kfp-operators
   kfp-ui:
     charm: kfp-ui
     channel: latest/edge
     scale: 1
+    trust: true
     _github_repo_name: kfp-operators
   kfp-viewer:
     charm: kfp-viewer
     channel: latest/edge
     scale: 1
+    trust: true
     _github_repo_name: kfp-operators
   kfp-viz:
     charm: kfp-viz


### PR DESCRIPTION
Trust rewritten kfp charms that were rewritten following the sidecar pattern. These are:
- kfp-persistence
- kfp-profile-controller
- kfp-schedwf
- kfp-ui
- kfp-viewer

Merge ONLY after https://github.com/canonical/kfp-operators/pull/288 is merged (the rest of the components have already been merged).