### PR TITLE
ci: Publish bundle to charmhub

### DIFF
--- a/.github/workflows/full-bundle-tests.yaml
+++ b/.github/workflows/full-bundle-tests.yaml
@@ -9,6 +9,16 @@ on:
       bundle-source:
         description: 'Either `--channel <channel_name>` or `--file <bundle_file>.yaml`'
         required: true
+  workflow_call:
+    inputs:
+      bundle-test-path:
+        description: 'Test folder to run'
+        type: string
+        required: true
+      bundle-source:
+        description: 'Either `--channel <channel_name>` or `--file <bundle_file>.yaml`'
+        type: string
+        required: true
 
 jobs:
   test-bundle:
@@ -102,9 +112,9 @@ jobs:
 
       - name: Run bundle tests
         run: |
-          export BUNDLE_TEST_PATH=${{ github.event.inputs.bundle-test-path }}
+          export BUNDLE_TEST_PATH=${{ inputs.bundle-test-path }}
           export GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          sg microk8s -c "tox -e full_bundle_tests -- ${{ github.event.inputs.bundle-source }}"
+          sg microk8s -c "tox -e full_bundle_tests -- ${{ inputs.bundle-source }}"
 
       - name: Upload selenium screenshots
         if: failure()

--- a/.github/workflows/release-bundle-to-charmhub.yaml
+++ b/.github/workflows/release-bundle-to-charmhub.yaml
@@ -1,0 +1,39 @@
+name: Publish bundle to Charmhub
+on:
+  push:
+    branches:
+    - main
+    paths:
+      - releases/**
+
+jobs:
+
+  get-releases-affected:
+    name: Get releases affected
+    runs-on: ubuntu-22.04
+    outputs:
+      releases_affected: ${{ steps.get-releases-affected.outputs.releases_affected_json }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get files changed
+        id: changed-files
+        uses: tj-actions/changed-files@v37
+
+      - name: Get releases affected
+        id: get-releases-affected
+        run: python scripts/get_releases_affected.py ${{ steps.changed-files.outputs.all_changed_files }}
+
+  run-tests-and-publish-bundle-for-releases-affected:
+    name: Run bundle tests and publish to Charmhub
+    needs: [get-releases-affected]
+    strategy:
+      fail-fast: false
+      matrix:
+        release: ${{ fromJson(needs.get-releases-affected.outputs.releases_affected) }}
+    uses: ./.github/workflows/run-tests-and-publish-bundle.yaml
+    with:
+      release: ${{ matrix.release }}
+    secrets: inherit

--- a/.github/workflows/run-tests-and-publish-bundle.yaml
+++ b/.github/workflows/run-tests-and-publish-bundle.yaml
@@ -1,0 +1,52 @@
+name: Run bundle tests and publish to Charmhub
+on:
+  workflow_call:
+    inputs:
+      release:
+        description: Bundle release to run tests on and publish to Charmhub
+        type: string
+        required: true
+    secrets:
+      CHARMCRAFT_CREDENTIALS:
+        required: true
+
+jobs:
+  get-release-inputs:
+    name: Get required inputs
+    runs-on: ubuntu-22.04
+    outputs:
+      bundle_path: ${{ steps.bundle-path.outputs.bundle_path }}
+      bundle_test_path: ${{ steps.bundle-test-path.outputs.bundle_test_path }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get bundle path for ${{ inputs.release }}
+        id: bundle-path
+        run: python scripts/get_bundle_path.py ${{ inputs.release }}
+
+      - name: Get bundle test path for ${{ inputs.release }}
+        id: bundle-test-path
+        run: python scripts/get_bundle_test_path.py ${{ inputs.release }}
+
+  run-tests:
+    name: Run tests
+    needs: [get-release-inputs]
+    uses: ./.github/workflows/full-bundle-tests.yaml
+    with:
+      bundle-test-path: ${{ needs.get-release-inputs.outputs.bundle_test_path }}
+      bundle-source: --file ${{ needs.get-release-inputs.outputs.bundle_path }}/bundle.yaml
+
+  publish-bundle-for-releases-affected:
+    name: Publish bundle
+    runs-on: ubuntu-22.04
+    needs: [get-release-inputs, run-tests]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Publish bundle release ${{ inputs.release }}
+        uses: canonical/charming-actions/upload-bundle@1.0.0
+        with:
+          credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          bundle-path: ${{ needs.get-release-inputs.outputs.bundle_path }}
+          channel: ${{ inputs.release }}

--- a/releases/latest/beta/README.md
+++ b/releases/latest/beta/README.md
@@ -1,0 +1,67 @@
+# Kubeflow Operators
+
+## Introduction
+
+Charmed Kubeflow is a full set of Kubernetes operators to deliver the 30+ applications and services
+that make up the latest version of Kubeflow, for easy operations anywhere, from workstations to
+on-prem, to public cloud and edge.
+
+A charm is a software package that includes an operator together with metadata that supports the
+integration of many operators in a coherent aggregated system.
+
+This technology leverages the Juju Operator Lifecycle Manager to provide day-0 to day-2 operations
+of Kubeflow.
+
+Visit [charmed-kubeflow.io][charmedkf] for more information.
+
+## Install
+
+
+For any Kubernetes, follow the [installation instructions][install].
+
+## Testing
+
+To deploy this bundle and run tests locally, do the following:
+
+1. Set up Kubernetes, Juju, and deploy the bundle you're interested in (`kubeflow` or
+   `kubeflow-lite`) using the [installation guide](https://charmed-kubeflow.io/docs/install/). This
+   must include populating the `.kube/config` file with your Kubernetes cluster as the active
+   context. Do not create a namespace with the same name as the username, this will cause 
+   pipelines tests to fail. Beware of using `admin` as the dex-auth static-username as the tests 
+   attempt to create a profile and `admin` conflicts with an existing default profile.
+2. Install test prerequisites:
+
+   ```bash
+   sudo snap install juju-wait --classic
+   sudo snap install juju-kubectl --classic
+   sudo snap install charmcraft --classic
+   sudo apt update
+   sudo apt install -y libssl-dev firefox-geckodriver
+   sudo pip3 install tox
+   sudo pip3 install -r requirements.txt
+   ```
+
+3. Run tests on your bundle with tox. As many tests need authentication, make sure you pass the
+   username and password you set in step (1) through environment variable or argument, for example:
+   - full bundle (using command line arguments):
+      ```
+      tox -e tests -- -m full --username user123@email.com --password user123
+      ```
+   - lite bundle (using environment variables):
+      ```
+      export KUBEFLOW_AUTH_USERNAME=user1234@email.com
+      export KUBEFLOW_AUTH_PASSWORD=user1234
+      tox -e tests -- -m lite
+      ```
+
+Subsets of the tests are also available using pytest's substring expression selector (e.g.:
+`tox -e tests -- -m full --username user123@email.com --password user123 -k 'selenium'` to run just
+the selenium tests).
+
+## Documentation
+
+Read the [official documentation][docs].
+
+[charmedkf]: https://charmed-kubeflow.io/
+[docs]: https://charmed-kubeflow.io/docs/
+[install]: https://charmed-kubeflow.io/docs/install

--- a/releases/latest/beta/charmcraft.yaml
+++ b/releases/latest/beta/charmcraft.yaml
@@ -1,0 +1,1 @@
+type: bundle

--- a/releases/latest/edge/README.md
+++ b/releases/latest/edge/README.md
@@ -1,0 +1,67 @@
+# Kubeflow Operators
+
+## Introduction
+
+Charmed Kubeflow is a full set of Kubernetes operators to deliver the 30+ applications and services
+that make up the latest version of Kubeflow, for easy operations anywhere, from workstations to
+on-prem, to public cloud and edge.
+
+A charm is a software package that includes an operator together with metadata that supports the
+integration of many operators in a coherent aggregated system.
+
+This technology leverages the Juju Operator Lifecycle Manager to provide day-0 to day-2 operations
+of Kubeflow.
+
+Visit [charmed-kubeflow.io][charmedkf] for more information.
+
+## Install
+
+
+For any Kubernetes, follow the [installation instructions][install].
+
+## Testing
+
+To deploy this bundle and run tests locally, do the following:
+
+1. Set up Kubernetes, Juju, and deploy the bundle you're interested in (`kubeflow` or
+   `kubeflow-lite`) using the [installation guide](https://charmed-kubeflow.io/docs/install/). This
+   must include populating the `.kube/config` file with your Kubernetes cluster as the active
+   context. Do not create a namespace with the same name as the username, this will cause 
+   pipelines tests to fail. Beware of using `admin` as the dex-auth static-username as the tests 
+   attempt to create a profile and `admin` conflicts with an existing default profile.
+2. Install test prerequisites:
+
+   ```bash
+   sudo snap install juju-wait --classic
+   sudo snap install juju-kubectl --classic
+   sudo snap install charmcraft --classic
+   sudo apt update
+   sudo apt install -y libssl-dev firefox-geckodriver
+   sudo pip3 install tox
+   sudo pip3 install -r requirements.txt
+   ```
+
+3. Run tests on your bundle with tox. As many tests need authentication, make sure you pass the
+   username and password you set in step (1) through environment variable or argument, for example:
+   - full bundle (using command line arguments):
+      ```
+      tox -e tests -- -m full --username user123@email.com --password user123
+      ```
+   - lite bundle (using environment variables):
+      ```
+      export KUBEFLOW_AUTH_USERNAME=user1234@email.com
+      export KUBEFLOW_AUTH_PASSWORD=user1234
+      tox -e tests -- -m lite
+      ```
+
+Subsets of the tests are also available using pytest's substring expression selector (e.g.:
+`tox -e tests -- -m full --username user123@email.com --password user123 -k 'selenium'` to run just
+the selenium tests).
+
+## Documentation
+
+Read the [official documentation][docs].
+
+[charmedkf]: https://charmed-kubeflow.io/
+[docs]: https://charmed-kubeflow.io/docs/
+[install]: https://charmed-kubeflow.io/docs/install

--- a/releases/latest/edge/charmcraft.yaml
+++ b/releases/latest/edge/charmcraft.yaml
@@ -1,0 +1,1 @@
+type: bundle

--- a/scripts/get_bundle_path.py
+++ b/scripts/get_bundle_path.py
@@ -1,0 +1,28 @@
+# Get bundle path for specific release
+import re
+import sys
+import os
+
+
+def get_bundle_path_from_release() -> None:
+    if len(sys.argv) > 1:
+        release = sys.argv[1]
+        bundle_is_latest = re.search("^latest/", release)
+        if bundle_is_latest:
+            bundle_path = "./releases/" + release + "/"
+        else:
+            bundle_path = "./releases/" + release + "/kubeflow/"
+
+        # Check if file in bundle_path output exists
+        # Expect the script to be executed from `bundle-kubeflow` repo directory
+        if os.path.exists(bundle_path):
+            print(f"Returning bundle_path={bundle_path}")
+            with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+                print(f'bundle_path={bundle_path}', file=fh)
+        else:
+            raise Exception(f"There is no file in path: {bundle_path}")
+    else:
+        raise Exception("No release given as input.")
+
+
+get_bundle_path_from_release()

--- a/scripts/get_bundle_path.py
+++ b/scripts/get_bundle_path.py
@@ -5,24 +5,24 @@ import os
 
 
 def get_bundle_path_from_release() -> None:
-    if len(sys.argv) > 1:
-        release = sys.argv[1]
-        bundle_is_latest = re.search("^latest/", release)
-        if bundle_is_latest:
-            bundle_path = "./releases/" + release + "/"
-        else:
-            bundle_path = "./releases/" + release + "/kubeflow/"
-
-        # Check if file in bundle_path output exists
-        # Expect the script to be executed from `bundle-kubeflow` repo directory
-        if os.path.exists(bundle_path):
-            print(f"Returning bundle_path={bundle_path}")
-            with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-                print(f'bundle_path={bundle_path}', file=fh)
-        else:
-            raise Exception(f"There is no file in path: {bundle_path}")
-    else:
+    if len(sys.argv) <= 1:
         raise Exception("No release given as input.")
+
+    release = sys.argv[1]
+    bundle_is_latest = re.search("^latest/", release)
+    if bundle_is_latest:
+        bundle_path = "./releases/" + release + "/"
+    else:
+        bundle_path = "./releases/" + release + "/kubeflow/"
+
+    # Check if file in bundle_path output exists
+    # Expect the script to be executed from `bundle-kubeflow` repo directory
+    if os.path.exists(bundle_path):
+        print(f"Returning bundle_path={bundle_path}")
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            print(f'bundle_path={bundle_path}', file=fh)
+    else:
+        raise Exception(f"There is no file in path: {bundle_path}")
 
 
 get_bundle_path_from_release()

--- a/scripts/get_bundle_test_path.py
+++ b/scripts/get_bundle_test_path.py
@@ -1,33 +1,40 @@
 # Get bundle test path for specific release
-import re
 import sys
 import os
 
+# For new releases, add a release/tests mapping to this dictionary
+RELEASE_TESTS = {
+    "1.6/beta": "./tests-bundle/1.6/",
+    "1.6/edge": "./tests-bundle/1.6/",
+    "1.6/stable": "./tests-bundle/1.6/",
+    "1.7/beta": "./tests-bundle/1.7/",
+    "1.7/edge": "./tests-bundle/1.7/",
+    "1.7/stable": "./tests-bundle/1.7/",
+    "latest/beta": "./tests-bundle/1.7/",
+    "latest/edge": "./tests-bundle/1.7/",
+}
+
 
 def get_bundle_test_path_from_release() -> None:
-    if len(sys.argv) > 1:
-        release = sys.argv[1]
-        bundle_is_1_6 = re.search("^1.6/", release)
-        bundle_is_1_4 = re.search("^1.4/", release)
-        if bundle_is_1_4:
-            raise Exception(
-                f"No tests available for 1.4 release. Please proceed to manually publish to Charmhub if needed."
-            )
-        elif bundle_is_1_6:
-            bundle_test_path = "./tests-bundle/1.6/"
-        else:
-            bundle_test_path = "./tests-bundle/1.7/"
-
-        # Check if file in bundle_test_path output exists
-        # Expect the script to be executed from `bundle-kubeflow` repo directory
-        if os.path.exists(bundle_test_path):
-            print(f"Returning bundle_test_path={bundle_test_path}")
-            with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-                print(f'bundle_test_path={bundle_test_path}', file=fh)
-        else:
-            raise Exception(f"There is no directory in path: {bundle_test_path}")
-    else:
+    if len(sys.argv) <= 1:
         raise Exception("No release given as input.")
+
+    release = sys.argv[1]
+
+    if release not in RELEASE_TESTS.keys():
+        raise Exception(
+            f"No tests available for {release} release. Please proceed to manually publish to Charmhub if needed."
+        )
+    bundle_test_path = RELEASE_TESTS[release]
+
+    # Check if file in bundle_test_path output exists
+    # Expect the script to be executed from `bundle-kubeflow` repo directory
+    if os.path.exists(bundle_test_path):
+        print(f"Returning bundle_test_path={bundle_test_path}")
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            print(f'bundle_test_path={bundle_test_path}', file=fh)
+    else:
+        raise Exception(f"There is no directory in path: {bundle_test_path}")
 
 
 get_bundle_test_path_from_release()

--- a/scripts/get_bundle_test_path.py
+++ b/scripts/get_bundle_test_path.py
@@ -1,0 +1,33 @@
+# Get bundle test path for specific release
+import re
+import sys
+import os
+
+
+def get_bundle_test_path_from_release() -> None:
+    if len(sys.argv) > 1:
+        release = sys.argv[1]
+        bundle_is_1_6 = re.search("^1.6/", release)
+        bundle_is_1_4 = re.search("^1.4/", release)
+        if bundle_is_1_4:
+            raise Exception(
+                f"No tests available for 1.4 release. Please proceed to manually publish to Charmhub if needed."
+            )
+        elif bundle_is_1_6:
+            bundle_test_path = "./tests-bundle/1.6/"
+        else:
+            bundle_test_path = "./tests-bundle/1.7/"
+
+        # Check if file in bundle_test_path output exists
+        # Expect the script to be executed from `bundle-kubeflow` repo directory
+        if os.path.exists(bundle_test_path):
+            print(f"Returning bundle_test_path={bundle_test_path}")
+            with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+                print(f'bundle_test_path={bundle_test_path}', file=fh)
+        else:
+            raise Exception(f"There is no directory in path: {bundle_test_path}")
+    else:
+        raise Exception("No release given as input.")
+
+
+get_bundle_test_path_from_release()

--- a/scripts/get_releases_affected.py
+++ b/scripts/get_releases_affected.py
@@ -1,0 +1,33 @@
+# Extract from the files changed by this PR the releases/channels affected.
+import re
+import sys
+import json
+import os
+
+def get_releases_affected() -> None:
+  releases_affected = set()
+
+  for file_path in sys.argv:
+      # check if string starts with the "releases"
+      file_path_starts_with_releases = re.search("^releases", file_path)
+
+      if file_path_starts_with_releases :
+        directories = file_path.split('/')
+        track = directories[1]
+        risk = directories[2]
+        accepted_tracks = ["1.4","1.6","1.7","latest"]
+        accepted_risks = ["beta","edge","stable"]
+
+        if(track in accepted_tracks and risk in accepted_risks):
+          release = f"{track}/{risk}"
+          releases_affected.add(release)
+        else:
+          raise Exception(f"File {file_path} was changed in 'releases' directory but it's not part of a known release/channel.")
+
+  releases_affected_json = json.dumps(list(releases_affected))
+  print(f"The following releases have been affected by this PR: {releases_affected_json}")
+  with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+    print(f'releases_affected_json={releases_affected_json}', file=fh)
+
+
+get_releases_affected()


### PR DESCRIPTION
This PR adds CI that automatically publishes bundle releases to Charmhub, if they have been modified/affected by a PR-commit pushed to `main`. Task https://warthogs.atlassian.net/browse/KF-4053.

In more detail, this introduces:
- Workflow that gets triggered when there are changes in a `releases` directory and only during push to `main` and it:
    - Detects which releases have been affected
    - Triggers the reusable WF, for each of the releases affected, in order to run bundle tests on it and if they succeed, it publishes the new bundle to Charmhub.
- reusable WF to run tests and publish to charmhub for a single release
- changes to full-bundle-tests workflow to make it reusable (by other WFs)
- script that, according to files changed, returns which bundle releases have been affected.
- script that returns the path to bundle.yaml for a bundle release.
- script that returns the path to bundle tests for a bundle release.

Here's a[ successful run of the CI](https://github.com/canonical/bundle-kubeflow/actions/runs/5923203081/job/16058416663?pr=657) that included some extra dummy commits (here is the [branch used for that run](https://github.com/canonical/bundle-kubeflow/compare/main...kf-4053-ci-publish-bundle-to-charmhub-with-dummy-commits)) in order to be triggered during `on: pull request:` and use a dummy WF instead of running the actual tests since the tests are not fixed yet. 