### PR TITLE
ci: Deploy EKS workflow deletes cluster after getting logs

### DIFF
--- a/.github/workflows/deploy-eks.yaml
+++ b/.github/workflows/deploy-eks.yaml
@@ -101,3 +101,4 @@ jobs:
     secrets: inherit
     with:
       region: eu-central-1
+    needs: [deploy-ckf-to-eks]

--- a/.github/workflows/deploy-eks.yaml
+++ b/.github/workflows/deploy-eks.yaml
@@ -65,11 +65,6 @@ jobs:
         run: |
           tox -vve test_bundle_deployment -- --model kubeflow --keep-models -vv -s
       
-      - name: Delete EKS cluster
-        if: always()
-        run: |
-          eksctl delete cluster --region eu-central-1 --name=kubeflow-test
-
       # On failure, capture debugging resources
       - name: Get juju status
         run: juju status
@@ -94,6 +89,11 @@ jobs:
       - name: Get logs from pods with status = CrashLoopBackOff
         run: kubectl -n kubeflow get pods | tail -n +2 | grep CrashLoopBackOff | awk '{print $1}' | xargs -n1 kubectl -n kubeflow logs --all-containers=true --tail 100
         if: failure()
+
+      - name: Delete EKS cluster
+        if: always()
+        run: |
+          eksctl delete cluster --region eu-central-1 --name=kubeflow-test
 
   delete-unattached-volumes:
     if: always()


### PR DESCRIPTION
Fix `deploy-eks.yaml` workflow so that in the case of failure, it deletes the cluster after getting relevant logs.