### PR TITLE
tests-bundle: Add action.wait() to test_profile_creation

### DIFF
--- a/tests-bundle/1.7/test_release_1-7.py
+++ b/tests-bundle/1.7/test_release_1-7.py
@@ -112,6 +112,7 @@ async def test_profile_creation_action(ops_test: OpsTest):
 
     Also, this will allow to test selenium and skip welcome page in dashboard UI.
     """
-    await ops_test.model.applications["kubeflow-profiles"].units[0].run_action(
+    action = await ops_test.model.applications["kubeflow-profiles"].units[0].run_action(
         "create-profile", profilename=f"{USERNAME}@email.com", username=USERNAME
     )
+    await action.wait()


### PR DESCRIPTION
Fix `test_profile_creation` test not waiting for profile to be created before being marked as `PASSED` and moving onto next test.