### PR TITLE
tests-bundle: Fix profile creation by modifying profilename

### DIFF
--- a/tests-bundle/1.7/test_release_1-7.py
+++ b/tests-bundle/1.7/test_release_1-7.py
@@ -113,6 +113,6 @@ async def test_profile_creation_action(ops_test: OpsTest):
     Also, this will allow to test selenium and skip welcome page in dashboard UI.
     """
     action = await ops_test.model.applications["kubeflow-profiles"].units[0].run_action(
-        "create-profile", profilename=f"{USERNAME}@email.com", username=USERNAME
+        "create-profile", profilename=USERNAME, username=USERNAME
     )
     await action.wait()


### PR DESCRIPTION
tests-bundle: Fix profile creation by modifying profilename. The error we were getting is 
```
lightkube.core.exceptions.ApiError: Profile.kubeflow.org "admin@email.com" is invalid: metadata.name: Invalid value: "admin@email.com": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```