### PR TITLE
fix: update workflow to accommodate new script

### DIFF
--- a/.github/workflows/scan-images.yaml
+++ b/.github/workflows/scan-images.yaml
@@ -51,7 +51,8 @@ jobs:
           cat ./image_list.txt
       - name: Scan images
         run: |
-          ./kubeflow-ci/scripts/images/scan-images.sh ./image_list.txt
+          cd ./kubeflow-ci/scripts/images/
+          ./scan-images.sh ./image_list.txt
           cp scan-summary.csv scan-summary-${{ steps.setup.outputs.date}}-${{ matrix.release }}-${{ matrix.risk }}.csv
       - name: Prepare artifacts
         run: |

--- a/.github/workflows/scan-images.yaml
+++ b/.github/workflows/scan-images.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           repository: canonical/kubeflow-ci.git
           sparse-checkout: scripts/images/
-          ref: fix-update-scan-script # FOR DEBUGGING
+          ref: main
           path: kubeflow-ci
       - name: Get images
         run: |

--- a/.github/workflows/scan-images.yaml
+++ b/.github/workflows/scan-images.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           repository: canonical/kubeflow-ci.git
           sparse-checkout: scripts/images/
-          ref: main
+          ref: fix-update-scan-script # FOR DEBUGGING
           path: kubeflow-ci
       - name: Get images
         run: |
@@ -51,9 +51,8 @@ jobs:
           cat ./image_list.txt
       - name: Scan images
         run: |
-          cd ./kubeflow-ci/scripts/images/
-          ./scan-images.sh ./image_list.txt
-          cp scan-summary.csv scan-summary-${{ steps.setup.outputs.date}}-${{ matrix.release }}-${{ matrix.risk }}.csv
+          ./kubeflow-ci/scripts/images/scan-images.sh ./image_list.txt
+          ./kubeflow-ci/scripts/images/get-summary.py --report-path ./trivy-reports --print-header > scan-summary-${{ steps.setup.outputs.date}}-${{ matrix.release }}-${{ matrix.risk }}.csv
       - name: Prepare artifacts
         run: |
           tar zcvf trivy-reports-${{ steps.setup.outputs.date}}-${{ matrix.release }}-${{ matrix.risk }}-${{ strategy.job-index }}.tar.gz ./trivy-reports


### PR DESCRIPTION
Image scan script was updated to use another Python script. As a result, update to workflow is required.

Issue and solution is described in https://github.com/canonical/bundle-kubeflow/issues/667

Kubeflow CI PRs:
https://github.com/canonical/kubeflow-ci/pull/104
https://github.com/canonical/kubeflow-ci/pull/105

Summary of changes:
- Updated scan images section of workflow to work with new kubeflow-ci scripts, i.e. two scripts: one for scanning, one for generating summary.

Test run of the workflow using PR branch: https://github.com/canonical/bundle-kubeflow/actions/runs/5917711692/job/16046303693
