### PR TITLE
bundle-tests: Disable Selenium tests as they are broken in CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ commands = pytest -v --tb native --show-capture=no {posargs} {toxinidir}/tests/
 # BUNDLE_TEST_PATH=tests-bundle/1.7 tox -e full_bundle_tests -- --channel=1.7/stable
 commands =
     pytest -vs --tb native -m deploy --model kubeflow --keep-models {env:BUNDLE_TEST_PATH} {posargs}
-    pytest -vs --tb native -m selenium --model kubeflow {env:BUNDLE_TEST_PATH} {posargs}
+    ; pytest -vs --tb native -m selenium --model kubeflow {env:BUNDLE_TEST_PATH} {posargs}
 passenv =
     BUNDLE_TEST_PATH
     GH_TOKEN

--- a/tox.ini
+++ b/tox.ini
@@ -53,6 +53,8 @@ commands = pytest -v --tb native --show-capture=no {posargs} {toxinidir}/tests/
 # BUNDLE_TEST_PATH=tests-bundle/1.7 tox -e full_bundle_tests -- --channel=1.7/stable
 commands =
     pytest -vs --tb native -m deploy --model kubeflow --keep-models {env:BUNDLE_TEST_PATH} {posargs}
+    ; Disabled temporarily until Selenium tests are fixed in CI and
+    ; https://github.com/canonical/bundle-kubeflow/issues/671 is closed
     ; pytest -vs --tb native -m selenium --model kubeflow {env:BUNDLE_TEST_PATH} {posargs}
 passenv =
     BUNDLE_TEST_PATH


### PR DESCRIPTION
Disable running bundle-tests with Selenium as they are broken at the moment. See https://github.com/canonical/bundle-kubeflow/issues/671.
Here's a [successful run](https://github.com/canonical/bundle-kubeflow/actions/runs/5938679642) from the PR's branch. 

This PR aims to make the [full-bundle-tests](https://github.com/canonical/bundle-kubeflow/blob/main/.github/workflows/full-bundle-tests.yaml) workflow usable, in order to be able to run tests and check that KF can be nomrally deployed. 