### PR TITLE
fix: added trust to kfp-viz to support new charm

### DIFF
--- a/releases/latest/edge/bundle.yaml
+++ b/releases/latest/edge/bundle.yaml
@@ -121,6 +121,7 @@ applications:
     charm: kfp-viz
     channel: latest/edge
     scale: 1
+    trust: 1
     _github_repo_name: kfp-operators
   knative-eventing:
     charm: knative-eventing


### PR DESCRIPTION
# Description

Kfp-viz charm was re-written using sidecar pattern and base charm class. In this case it requires to be deployed with trust.
This PR will address this by adding trust to edge bundle.

Summary of changes:
- Added trust to kfp-viz to support newly re-written charm https://github.com/canonical/kfp-operators/pull/309