### PR TITLE
feat: added latest to scan

### DIFF
--- a/.github/workflows/scan-images.yaml
+++ b/.github/workflows/scan-images.yaml
@@ -48,7 +48,7 @@ jobs:
           BUNDLE_SPLIT=(${BUNDLE//\// })
           RELEASE=${BUNDLE_SPLIT[0]}
           RISK=${BUNDLE_SPLIT[1]}
-          IMAGES=$(./kubeflow-ci/scripts/images/get-all-images.sh releases/${RELEASE}/${RISK}/kubeflow/bundle.yaml ${RELEASE}-${RISK}
+          IMAGES=$(./kubeflow-ci/scripts/images/get-all-images.sh releases/${RELEASE}/${RISK}/kubeflow/bundle.yaml ${RELEASE}-${RISK})
           echo "$IMAGES" > ./image_list.txt
           echo "Image list:"
           cat ./image_list.txt

--- a/.github/workflows/scan-images.yaml
+++ b/.github/workflows/scan-images.yaml
@@ -48,7 +48,7 @@ jobs:
           BUNDLE_SPLIT=(${BUNDLE//\// })
           RELEASE=${BUNDLE_SPLIT[0]}
           RISK=${BUNDLE_SPLIT[1]}
-          IMAGES=$(./kubeflow-ci/scripts/images/get-all-images.sh releases/${BUNDLE}/kubeflow/bundle.yaml ${RELEASE}-${RISK}
+          IMAGES=$(./kubeflow-ci/scripts/images/get-all-images.sh releases/${RELEASE}/${RISK}/kubeflow/bundle.yaml ${RELEASE}-${RISK}
           echo "$IMAGES" > ./image_list.txt
           echo "Image list:"
           cat ./image_list.txt

--- a/.github/workflows/scan-images.yaml
+++ b/.github/workflows/scan-images.yaml
@@ -10,7 +10,8 @@ jobs:
     name: Scan images in bundle
     strategy:
       matrix:
-        bundle: [ 1.7/stable, latest/edge ]
+        # specfy location of bundle to be tested relative to releases/
+        bundle: [ 1.7/stable/kubeflow, latest/edge ]
     runs-on: ubuntu-20.04
     steps:
       # Ideally we'd use self-hosted runners, but this effort is still not stable
@@ -48,7 +49,7 @@ jobs:
           BUNDLE_SPLIT=(${BUNDLE//\// })
           RELEASE=${BUNDLE_SPLIT[0]}
           RISK=${BUNDLE_SPLIT[1]}
-          IMAGES=$(./kubeflow-ci/scripts/images/get-all-images.sh releases/${RELEASE}/${RISK}/kubeflow/bundle.yaml ${RELEASE}-${RISK})
+          IMAGES=$(./kubeflow-ci/scripts/images/get-all-images.sh releases/${{ matrix.bundle }}/bundle.yaml ${RELEASE}-${RISK})
           echo "$IMAGES" > ./image_list.txt
           echo "Image list:"
           cat ./image_list.txt

--- a/.github/workflows/scan-images.yaml
+++ b/.github/workflows/scan-images.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Scan images in bundle
     strategy:
       matrix:
-        bundle: [ 1.7/stable, latest/edge ]
+        bundle: [ "1.7/stable", "latest/edge" ]
     runs-on: ubuntu-20.04
     steps:
       # Ideally we'd use self-hosted runners, but this effort is still not stable

--- a/.github/workflows/scan-images.yaml
+++ b/.github/workflows/scan-images.yaml
@@ -10,8 +10,8 @@ jobs:
     name: Scan images in bundle
     strategy:
       matrix:
-        # specfy location of bundle to be tested relative to releases/
-        bundle: [ 1.7/stable/kubeflow, latest/edge ]
+        # specfy location of bundle(s) to be scanned
+        bundle: [ releases/1.7/stable/kubeflow, releases/latest/edge ]
     runs-on: ubuntu-20.04
     steps:
       # Ideally we'd use self-hosted runners, but this effort is still not stable
@@ -47,9 +47,9 @@ jobs:
         run: |
           BUNDLE="${{ matrix.bundle }}"
           BUNDLE_SPLIT=(${BUNDLE//\// })
-          RELEASE=${BUNDLE_SPLIT[0]}
-          RISK=${BUNDLE_SPLIT[1]}
-          IMAGES=$(./kubeflow-ci/scripts/images/get-all-images.sh releases/${{ matrix.bundle }}/bundle.yaml ${RELEASE}-${RISK})
+          RELEASE=${BUNDLE_SPLIT[1]}
+          RISK=${BUNDLE_SPLIT[2]}
+          IMAGES=$(./kubeflow-ci/scripts/images/get-all-images.sh ${{ matrix.bundle }}/bundle.yaml ${RELEASE}-${RISK})
           echo "$IMAGES" > ./image_list.txt
           echo "Image list:"
           cat ./image_list.txt

--- a/.github/workflows/scan-images.yaml
+++ b/.github/workflows/scan-images.yaml
@@ -10,8 +10,7 @@ jobs:
     name: Scan images in bundle
     strategy:
       matrix:
-        release: [ 1.7, latest ]
-        risk: [ stable, edge ]
+        bundle: [ 1.7/stable, latest/edge ]
     runs-on: ubuntu-20.04
     steps:
       # Ideally we'd use self-hosted runners, but this effort is still not stable
@@ -45,7 +44,11 @@ jobs:
           path: kubeflow-ci
       - name: Get images
         run: |
-          IMAGES=$(./kubeflow-ci/scripts/images/get-all-images.sh releases/${{ matrix.release }}/${{ matrix.risk }}/kubeflow/bundle.yaml ${{ matrix.release }}-${{ matrix.risk }})
+          BUNDLE=${{ matrix.bundle }}
+          BUNDLE_SPLIT=(${BUNDLE//\// })
+          RELEASE=${BUNDLE_SPLIT[0]}
+          RISK=${BUNDLE_SPLIT[1]}
+          IMAGES=$(./kubeflow-ci/scripts/images/get-all-images.sh releases/${BUNDLE}/kubeflow/bundle.yaml ${RELEASE}-${RISK}
           echo "$IMAGES" > ./image_list.txt
           echo "Image list:"
           cat ./image_list.txt

--- a/.github/workflows/scan-images.yaml
+++ b/.github/workflows/scan-images.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Scan images in bundle
     strategy:
       matrix:
-        bundle: [ "1.7/stable", "latest/edge" ]
+        bundle: [ 1.7/stable, latest/edge ]
     runs-on: ubuntu-20.04
     steps:
       # Ideally we'd use self-hosted runners, but this effort is still not stable
@@ -44,7 +44,7 @@ jobs:
           path: kubeflow-ci
       - name: Get images
         run: |
-          BUNDLE=${{ matrix.bundle }}
+          BUNDLE="${{ matrix.bundle }}"
           BUNDLE_SPLIT=(${BUNDLE//\// })
           RELEASE=${BUNDLE_SPLIT[0]}
           RISK=${BUNDLE_SPLIT[1]}

--- a/.github/workflows/scan-images.yaml
+++ b/.github/workflows/scan-images.yaml
@@ -10,8 +10,8 @@ jobs:
     name: Scan images in bundle
     strategy:
       matrix:
-        release: [ 1.7 ]
-        risk: [ stable ]
+        release: [ 1.7, latest ]
+        risk: [ stable, edge ]
     runs-on: ubuntu-20.04
     steps:
       # Ideally we'd use self-hosted runners, but this effort is still not stable

--- a/releases/latest/edge/bundle.yaml
+++ b/releases/latest/edge/bundle.yaml
@@ -121,6 +121,7 @@ applications:
     charm: kfp-viz
     channel: latest/edge
     scale: 1
+    trust: true
     _github_repo_name: kfp-operators
   knative-eventing:
     charm: knative-eventing


### PR DESCRIPTION
# Description

Update to scan image workflow is needed to scan latest/edge bundle.

More details are in: https://github.com/canonical/bundle-kubeflow/issues/679

Summary of changes:
- Added latest to scan matrix.
- Workflow is redesigned to improve handling of multipole releases and avoid running scans on not required bundles.
