### PR TITLE
build: deploy argo-controller with trust

### DIFF
--- a/releases/latest/beta/bundle.yaml
+++ b/releases/latest/beta/bundle.yaml
@@ -11,6 +11,7 @@ applications:
   argo-controller:
     charm: argo-controller
     channel: latest/beta
+    trust: True
     scale: 1
     _github_repo_name: argo-operators
   argo-server:

--- a/releases/latest/edge/bundle-airgap.yaml
+++ b/releases/latest/edge/bundle-airgap.yaml
@@ -10,6 +10,7 @@ applications:
   argo-controller:
     charm: ./argo-controller_b59eaec.charm
     scale: 1
+    trust: true
     resources:
       oci-image: 172.17.0.2:5000/argoproj/workflow-controller:v3.3.8
     options:

--- a/releases/latest/edge/bundle.yaml
+++ b/releases/latest/edge/bundle.yaml
@@ -12,6 +12,7 @@ applications:
   argo-controller:
     charm: argo-controller
     channel: latest/edge
+    trust: true
     scale: 1
     _github_repo_name: argo-operators
     _github_repo_branch: main


### PR DESCRIPTION
Deploy argo-controller with trust as a result of the charm rewrite in canonical/argo-operators#127