### PR TITLE
fix: change metacontroller image tag in bundle-airgap.yaml

### DIFF
--- a/releases/latest/edge/bundle-airgap.yaml
+++ b/releases/latest/edge/bundle-airgap.yaml
@@ -192,7 +192,7 @@ applications:
     scale: 1
     trust: true
     options:
-      metacontroller-image: 172.17.0.2:5000/metacontrollerio/metacontroller:v3.0.0
+      metacontroller-image: 172.17.0.2:5000/metacontrollerio/metacontroller:v2.0.4
   minio:
     charm: ./minio_0d03693.charm
     scale: 1


### PR DESCRIPTION
the metacontroller image was downgraded in https://github.com/canonical/metacontroller-operator/pull/85
this change needs to be reflected in the airgap bundle definition for `latest/edge`