### PR TITLE
latest/edge: Trust oidc-gatekeeper

### DIFF
--- a/releases/latest/edge/bundle.yaml
+++ b/releases/latest/edge/bundle.yaml
@@ -226,6 +226,7 @@ applications:
     charm: oidc-gatekeeper
     channel: latest/edge
     scale: 1
+    trust: true
     _github_repo_name: oidc-gatekeeper-operator
     _github_repo_branch: main
   seldon-controller-manager:


### PR DESCRIPTION
Add trust: true to oidc-gatekeeper charm in latest/edge bundle.yaml file.

Fixes #708 