### PR TITLE
fix: remove argo-server from latest/edge

### DIFF
--- a/releases/latest/edge/airgap/podspec_script.sh
+++ b/releases/latest/edge/airgap/podspec_script.sh
@@ -1,6 +1,5 @@
 # A script to deploy PodSpec charms, these cannot be included in the bundle definition due to https://github.com/canonical/bundle-kubeflow/issues/693
 juju deploy ./argo-controller_980dd9f.charm --resource oci-image=172.17.0.2:5000/argoproj/workflow-controller:v3.3.10 --config executor-image=172.17.0.2:5000/argoproj/argoexec:v3.3.8
-juju deploy ./argo-server_2618292.charm --resource oci-image=172.17.0.2:5000/argoproj/argocli:v3.3.8
 juju deploy ./katib-controller_f371975.charm \
     --resource oci-image=172.17.0.2:5000/kubeflowkatib/katib-controller:v0.16.0-rc.1 \
     --config custom_images='{"default_trial_template": "172.17.0.2:5000/kubeflowkatib/mxnet-mnist:v0.16.0-rc.1", \

--- a/releases/latest/edge/bundle.yaml
+++ b/releases/latest/edge/bundle.yaml
@@ -16,12 +16,6 @@ applications:
     scale: 1
     _github_repo_name: argo-operators
     _github_repo_branch: main
-  argo-server:
-    charm: argo-server
-    channel: latest/edge
-    scale: 1
-    _github_repo_name: argo-operators
-    _github_repo_branch: main
   dex-auth:
     charm: dex-auth
     channel: latest/edge


### PR DESCRIPTION
argo-server charm is not utilized in the charmed kubeflow bundle. The UI is not accessible to users atm.
This removes it from latest/edge bundle.yaml and  latest/edge air-gapped bundle.