### PR TITLE
latest/edge: Add pvcviewer-operator to bundle.yaml

### DIFF
--- a/releases/latest/edge/bundle.yaml
+++ b/releases/latest/edge/bundle.yaml
@@ -223,6 +223,13 @@ applications:
     trust: true
     _github_repo_name: oidc-gatekeeper-operator
     _github_repo_branch: main
+  pvcviewer-operator:
+    charm: pvcviewer-operator
+    channe: latest/edge
+    scale: 1
+    trust: true
+    _github_repo_name: pvcviewer-operator
+    _github_repo_branch: main
   seldon-controller-manager:
     charm: seldon-core
     channel: latest/edge

--- a/releases/latest/edge/bundle.yaml
+++ b/releases/latest/edge/bundle.yaml
@@ -225,7 +225,7 @@ applications:
     _github_repo_branch: main
   pvcviewer-operator:
     charm: pvcviewer-operator
-    channe: latest/edge
+    channel: latest/edge
     scale: 1
     trust: true
     _github_repo_name: pvcviewer-operator


### PR DESCRIPTION
Add [pvcviewer-operator](https://github.com/canonical/pvcviewer-operator) to `latest/edge` bundle.yaml. I didn't include this in `bundle-airgap.yaml` but filed this issue https://github.com/canonical/bundle-kubeflow/issues/718.