### PR TITLE
fix: update 1.8/beta bundle definition

### DIFF
--- a/releases/1.8/beta/bundle.yaml
+++ b/releases/1.8/beta/bundle.yaml
@@ -73,7 +73,7 @@ applications:
     _github_repo_name: katib-operators
   kfp-api:
     charm: kfp-api
-    channel: latest/edge
+    channel: 2.0/edge
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
@@ -85,37 +85,37 @@ applications:
     constraints: mem=2G
   kfp-persistence:
     charm: kfp-persistence
-    channel: latest/edge
+    channel: 2.0/edge
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
   kfp-profile-controller:
     charm: kfp-profile-controller
-    channel: latest/edge
+    channel: 2.0/edge
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
   kfp-schedwf:
     charm: kfp-schedwf
-    channel: latest/edge
+    channel: 2.0/edge
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
   kfp-ui:
     charm: kfp-ui
-    channel: latest/edge
+    channel: 2.0/edge
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
   kfp-viewer:
     charm: kfp-viewer
-    channel: latest/edge
+    channel: 2.0/edge
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
   kfp-viz:
     charm: kfp-viz
-    channel: latest/edge
+    channel: 2.0/edge
     scale: 1
     trust: true
     _github_repo_name: kfp-operators

--- a/releases/1.8/beta/bundle.yaml
+++ b/releases/1.8/beta/bundle.yaml
@@ -73,7 +73,7 @@ applications:
     _github_repo_name: katib-operators
   kfp-api:
     charm: kfp-api
-    channel: latest/beta
+    channel: latest/edge
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
@@ -85,37 +85,37 @@ applications:
     constraints: mem=2G
   kfp-persistence:
     charm: kfp-persistence
-    channel: latest/beta
+    channel: latest/edge
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
   kfp-profile-controller:
     charm: kfp-profile-controller
-    channel: latest/beta
+    channel: latest/edge
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
   kfp-schedwf:
     charm: kfp-schedwf
-    channel: latest/beta
+    channel: latest/edge
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
   kfp-ui:
     charm: kfp-ui
-    channel: latest/beta
+    channel: latest/edge
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
   kfp-viewer:
     charm: kfp-viewer
-    channel: latest/beta
+    channel: latest/edge
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
   kfp-viz:
     charm: kfp-viz
-    channel: latest/beta
+    channel: latest/edge
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
@@ -157,7 +157,7 @@ applications:
     _github_repo_name: kubeflow-dashboard-operator
   kubeflow-profiles:
     charm: kubeflow-profiles
-    channel: latest/beta
+    channel: 1.7/edge
     scale: 1
     trust: true
     _github_repo_name: kubeflow-profiles-operator
@@ -197,7 +197,7 @@ applications:
     _github_repo_name: pvcviewer-operator
   seldon-controller-manager:
     charm: seldon-core
-    channel: latest/beta
+    channel: latest/edge
     scale: 1
     trust: true
     _github_repo_name: seldon-core-operator


### PR DESCRIPTION
## Summary of changes:
* point `kfp-operators` charms to `2.0/edge` due to https://github.com/canonical/kfp-operators/issues/343
* point `seldon-controller-manager` charm to `latest/edge` due to https://github.com/canonical/seldon-core-operator/issues/218
* point `kubeflow-profiles-operator` charm to `1.7/edge` due to https://github.com/canonical/notebook-operators/issues/309