### PR TITLE
CI step for publishing should not depend on tests

### DIFF
--- a/.github/workflows/run-tests-and-publish-bundle.yaml
+++ b/.github/workflows/run-tests-and-publish-bundle.yaml
@@ -42,6 +42,7 @@ jobs:
   publish-bundle-for-releases-affected:
     name: Publish bundle
     runs-on: ubuntu-22.04
+    # we'll need to add back `run-tests` in the `needs` part, once we bring it back
     needs: [get-release-inputs]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/run-tests-and-publish-bundle.yaml
+++ b/.github/workflows/run-tests-and-publish-bundle.yaml
@@ -42,7 +42,7 @@ jobs:
   publish-bundle-for-releases-affected:
     name: Publish bundle
     runs-on: ubuntu-22.04
-    needs: [get-release-inputs, run-tests]
+    needs: [get-release-inputs]
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Follow-up from https://github.com/canonical/bundle-kubeflow/pull/722

We'll also need to ensure the publish action does not depend on the, now commented out, `run-tests` step