### PR TITLE
Trigger publish workflow with workflow_dispatch

### DIFF
--- a/.github/workflows/run-tests-and-publish-bundle.yaml
+++ b/.github/workflows/run-tests-and-publish-bundle.yaml
@@ -9,6 +9,15 @@ on:
     secrets:
       CHARMCRAFT_CREDENTIALS:
         required: true
+  workflow_dispatch:
+    inputs:
+      release:
+        description: Bundle release to run tests on and publish to Charmhub
+        type: string
+        required: true
+    secrets:
+      CHARMCRAFT_CREDENTIALS:
+        required: true
 
 jobs:
   get-release-inputs:


### PR DESCRIPTION
Make the workflow triggerable, in order to be able to publish the bundle whenever we need manually.