### PR TITLE
fix: pin argo to 3.3/stable in 1.8/beta

### DIFF
--- a/releases/1.8/beta/bundle.yaml
+++ b/releases/1.8/beta/bundle.yaml
@@ -10,7 +10,7 @@ applications:
     _github_repo_name: admission-webhook-operator
   argo-controller:
     charm: argo-controller
-    channel: latest/edge
+    channel: 3.3/stable
     trust: true
     scale: 1
     _github_repo_name: argo-operators


### PR DESCRIPTION
modifies the `1.8/beta` bundle definition to include `argo-controller` `3.3/stable` rather than `latest/edge` due to issue https://github.com/canonical/kfp-operators/issues/345