### PR TITLE
fix: argo-controller channel in 1.8/beta

### DIFF
--- a/releases/1.8/beta/kubeflow/bundle.yaml
+++ b/releases/1.8/beta/kubeflow/bundle.yaml
@@ -10,7 +10,7 @@ applications:
     _github_repo_name: admission-webhook-operator
   argo-controller:
     charm: argo-controller
-    channel: 3.3/stable
+    channel: latest/beta
     trust: true
     scale: 1
     _github_repo_name: argo-operators


### PR DESCRIPTION
changes `argo-controller` channel in `1.8/beta` bundle definition to `latest/beta`, `argo-controller` was originally pinned to `3.3/stable` due to issue https://github.com/canonical/kfp-operators/issues/345, the issue is now resolved so we can update argo.