### PR TITLE
chore: point all CKF charms to 1.8/beta channel to match release

### DIFF
--- a/releases/1.8/beta/kubeflow/bundle.yaml
+++ b/releases/1.8/beta/kubeflow/bundle.yaml
@@ -8,31 +8,35 @@ applications:
     trust: true
     scale: 1
     _github_repo_name: admission-webhook-operator
-    _github_repo_branch: 1.8/beta
+    _github_repo_branch: track/1.8
   argo-controller:
     charm: argo-controller
     channel: 3.3.10/beta
     trust: true
     scale: 1
     _github_repo_name: argo-operators
+    _github_repo_branch: track/3.3.10
   dex-auth:
     charm: dex-auth
     channel: 2.36/beta
     scale: 1
     trust: true
     _github_repo_name: dex-auth-operator
+    _github_repo_branch: track/2.36
   envoy:
     charm: envoy
     channel: 2.0/beta
     scale: 1
     trust: true
     _github_repo_name: envoy-operator
+    _github_repo_branch: track/2.0
   istio-ingressgateway:
     charm: istio-gateway
     channel: 1.17/beta
     scale: 1
     trust: true
     _github_repo_name: istio-operators
+    _github_repo_branch: track/1.17
     options:
       kind: ingress
   istio-pilot:
@@ -41,6 +45,7 @@ applications:
     scale: 1
     trust: true
     _github_repo_name: istio-operators
+    _github_repo_branch: track/1.17
     options:
       default-gateway: kubeflow-gateway
   jupyter-controller:
@@ -49,17 +54,20 @@ applications:
     scale: 1
     trust: true
     _github_repo_name: notebook-operators
+    _github_repo_branch: track/1.8
   jupyter-ui:
     charm: jupyter-ui
     channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: notebook-operators
+    _github_repo_branch: track/1.8
   katib-controller:
     charm: katib-controller
-    channel: 1.8/beta
+    channel: 0.16/beta
     scale: 1
     _github_repo_name: katib-operators
+    _github_repo_branch: track/0.16
   katib-db:
     charm: mysql-k8s
     channel: 8.0/stable
@@ -68,22 +76,25 @@ applications:
     constraints: mem=2G
   katib-db-manager:
     charm: katib-db-manager
-    channel: 1.8/beta
+    channel: 0.16/beta
     scale: 1
     trust: true
     _github_repo_name: katib-operators
+    _github_repo_branch: track/0.16
   katib-ui:
     charm: katib-ui
     channel: 0.16/beta
     scale: 1
     trust: true
     _github_repo_name: katib-operators
+    _github_repo_branch: track/0.16
   kfp-api:
     charm: kfp-api
     channel: 2.0/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
+    _github_repo_branch: track/2.0
   kfp-db:
     charm: mysql-k8s
     channel: 8.0/stable
@@ -96,42 +107,49 @@ applications:
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
+    _github_repo_branch: track/2.0
   kfp-persistence:
     charm: kfp-persistence
     channel: 2.0/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
+    _github_repo_branch: track/2.0
   kfp-profile-controller:
     charm: kfp-profile-controller
     channel: 2.0/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
+    _github_repo_branch: track/2.0
   kfp-schedwf:
     charm: kfp-schedwf
     channel: 2.0/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
+    _github_repo_branch: track/2.0
   kfp-ui:
     charm: kfp-ui
     channel: 2.0/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
+    _github_repo_branch: track/2.0
   kfp-viewer:
     charm: kfp-viewer
     channel: 2.0/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
+    _github_repo_branch: track/2.0
   kfp-viz:
     charm: kfp-viz
     channel: 2.0/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
+    _github_repo_branch: track/2.0
   knative-eventing:
     charm: knative-eventing
     channel: 1.10/beta
@@ -140,12 +158,14 @@ applications:
     options:
       namespace: knative-eventing
     _github_repo_name: knative-operators
+    _github_repo_branch: track/1.10
   knative-operator:
     charm: knative-operator
     channel: 1.10/beta
     scale: 1
     trust: true
     _github_repo_name: knative-operators
+    _github_repo_branch: track/1.10
   knative-serving:
     charm: knative-serving
     channel: 1.10/beta
@@ -156,57 +176,67 @@ applications:
       istio.gateway.namespace: kubeflow
       istio.gateway.name: kubeflow-gateway
     _github_repo_name: knative-operators
+    _github_repo_branch: track/1.10
   kserve-controller:
     charm: kserve-controller
-    channel: 1.8/beta
+    channel: 0.11/beta
     scale: 1
     trust: true
     _github_repo_name: kserve-operators
+    _github_repo_branch: track/0.11
   kubeflow-dashboard:
     charm: kubeflow-dashboard
     channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: kubeflow-dashboard-operator
+    _github_repo_branch: track/1.8
   kubeflow-profiles:
     charm: kubeflow-profiles
     channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: kubeflow-profiles-operator
+    _github_repo_branch: track/1.8
   kubeflow-roles:
     charm: kubeflow-roles
     channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: kubeflow-roles-operator
+    _github_repo_branch: track/1.8
   kubeflow-volumes:
     charm: kubeflow-volumes
     channel: 1.8/beta
     scale: 1
     _github_repo_name: kubeflow-volumes-operator
+    _github_repo_branch: track/1.8
   metacontroller-operator:
     charm: metacontroller-operator
     channel: 3.0/beta
     scale: 1
     trust: true
     _github_repo_name: metacontroller-operator
+    _github_repo_branch: track/3.0
   mlmd:
     charm: mlmd
     channel: 1.14/beta
     scale: 1
     _github_repo_name: mlmd-operator
+    _github_repo_branch: track/1.14
   minio:
     charm: minio
     channel: ckf-1.8/beta
     scale: 1
     _github_repo_name: minio-operator
+    _github_repo_branch: track/ckf-1.8
   oidc-gatekeeper:
     charm: oidc-gatekeeper
     channel: ckf-1.8/beta
     scale: 1
     trust: true
     _github_repo_name: oidc-gatekeeper-operator
+    _github_repo_branch: track/ckf-1.8
   pvcviewer-operator:
     charm: pvcviewer-operator
     channel: 1.8/beta
@@ -214,30 +244,35 @@ applications:
     trust: true
     series: focal
     _github_repo_name: pvcviewer-operator
+    _github_repo_branch: track/1.8
   seldon-controller-manager:
     charm: seldon-core
     channel: 1.17/beta
     scale: 1
     trust: true
     _github_repo_name: seldon-core-operator
+    _github_repo_branch: track/1.17
   tensorboard-controller:
     charm: tensorboard-controller
     channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: kubeflow-tensorboards-operator
+    _github_repo_branch: track/1.8
   tensorboards-web-app:
     charm: tensorboards-web-app
     channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: kubeflow-tensorboards-operator
+    _github_repo_branch: track/1.8
   training-operator:
     charm: training-operator
     channel: 1.7/beta
     scale: 1
     trust: true
     _github_repo_name: training-operator
+    _github_repo_branch: track/1.7
 relations:
   - [argo-controller, minio]
   - [dex-auth:oidc-client, oidc-gatekeeper:oidc-client]

--- a/releases/1.8/beta/kubeflow/bundle.yaml
+++ b/releases/1.8/beta/kubeflow/bundle.yaml
@@ -8,21 +8,28 @@ applications:
     trust: true
     scale: 1
     _github_repo_name: admission-webhook-operator
+    _github_repo_branch: 1.8/beta
   argo-controller:
     charm: argo-controller
-    channel: 1.8/beta
+    channel: 3.3.10/beta
     trust: true
     scale: 1
     _github_repo_name: argo-operators
   dex-auth:
     charm: dex-auth
-    channel: 1.8/beta
+    channel: 2.36/beta
     scale: 1
     trust: true
     _github_repo_name: dex-auth-operator
+  envoy:
+    charm: envoy
+    channel: 2.0/beta
+    scale: 1
+    trust: true
+    _github_repo_name: envoy-operator
   istio-ingressgateway:
     charm: istio-gateway
-    channel: 1.8/beta
+    channel: 1.17/beta
     scale: 1
     trust: true
     _github_repo_name: istio-operators
@@ -30,7 +37,7 @@ applications:
       kind: ingress
   istio-pilot:
     charm: istio-pilot
-    channel: 1.8/beta
+    channel: 1.17/beta
     scale: 1
     trust: true
     _github_repo_name: istio-operators
@@ -67,13 +74,13 @@ applications:
     _github_repo_name: katib-operators
   katib-ui:
     charm: katib-ui
-    channel: 1.8/beta
+    channel: 0.16/beta
     scale: 1
     trust: true
     _github_repo_name: katib-operators
   kfp-api:
     charm: kfp-api
-    channel: 1.8/beta
+    channel: 2.0/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
@@ -83,45 +90,51 @@ applications:
     scale: 1
     trust: true
     constraints: mem=2G
+  kfp-metadata-writer:
+    charm: kfp-metadata-writer
+    channel: 2.0/beta
+    scale: 1
+    trust: true
+    _github_repo_name: kfp-operators
   kfp-persistence:
     charm: kfp-persistence
-    channel: 1.8/beta
+    channel: 2.0/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
   kfp-profile-controller:
     charm: kfp-profile-controller
-    channel: 1.8/beta
+    channel: 2.0/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
   kfp-schedwf:
     charm: kfp-schedwf
-    channel: 1.8/beta
+    channel: 2.0/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
   kfp-ui:
     charm: kfp-ui
-    channel: 1.8/beta
+    channel: 2.0/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
   kfp-viewer:
     charm: kfp-viewer
-    channel: 1.8/beta
+    channel: 2.0/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
   kfp-viz:
     charm: kfp-viz
-    channel: 1.8/beta
+    channel: 2.0/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
   knative-eventing:
     charm: knative-eventing
-    channel: 1.8/beta
+    channel: 1.10/beta
     scale: 1
     trust: true
     options:
@@ -129,13 +142,13 @@ applications:
     _github_repo_name: knative-operators
   knative-operator:
     charm: knative-operator
-    channel: 1.8/beta
+    channel: 1.10/beta
     scale: 1
     trust: true
     _github_repo_name: knative-operators
   knative-serving:
     charm: knative-serving
-    channel: 1.8/beta
+    channel: 1.10/beta
     scale: 1
     trust: true
     options:
@@ -174,18 +187,23 @@ applications:
     _github_repo_name: kubeflow-volumes-operator
   metacontroller-operator:
     charm: metacontroller-operator
-    channel: 1.8/beta
+    channel: 3.0/beta
     scale: 1
     trust: true
     _github_repo_name: metacontroller-operator
+  mlmd:
+    charm: mlmd
+    channel: 1.14/beta
+    scale: 1
+    _github_repo_name: mlmd-operator
   minio:
     charm: minio
-    channel: 1.8/beta
+    channel: ckf-1.8/beta
     scale: 1
     _github_repo_name: minio-operator
   oidc-gatekeeper:
     charm: oidc-gatekeeper
-    channel: 1.8/beta
+    channel: ckf-1.8/beta
     scale: 1
     trust: true
     _github_repo_name: oidc-gatekeeper-operator
@@ -194,10 +212,11 @@ applications:
     channel: 1.8/beta
     scale: 1
     trust: true
+    series: focal
     _github_repo_name: pvcviewer-operator
   seldon-controller-manager:
     charm: seldon-core
-    channel: 1.8/beta
+    channel: 1.17/beta
     scale: 1
     trust: true
     _github_repo_name: seldon-core-operator
@@ -215,7 +234,7 @@ applications:
     _github_repo_name: kubeflow-tensorboards-operator
   training-operator:
     charm: training-operator
-    channel: 1.8/beta
+    channel: 1.7/beta
     scale: 1
     trust: true
     _github_repo_name: training-operator
@@ -223,6 +242,7 @@ relations:
   - [argo-controller, minio]
   - [dex-auth:oidc-client, oidc-gatekeeper:oidc-client]
   - [istio-pilot:ingress, dex-auth:ingress]
+  - [istio-pilot:ingress, envoy:ingress]
   - [istio-pilot:ingress, jupyter-ui:ingress]
   - [istio-pilot:ingress, katib-ui:ingress]
   - [istio-pilot:ingress, kfp-ui:ingress]
@@ -249,3 +269,5 @@ relations:
   - [kubeflow-dashboard:links, kfp-ui:dashboard-links]
   - [kubeflow-dashboard:links, kubeflow-volumes:dashboard-links]
   - [kubeflow-dashboard:links, tensorboards-web-app:dashboard-links]
+  - [mlmd:grpc, envoy:grpc]
+  - [mlmd:grpc, kfp-metadata-writer:grpc]

--- a/releases/1.8/beta/kubeflow/bundle.yaml
+++ b/releases/1.8/beta/kubeflow/bundle.yaml
@@ -4,25 +4,25 @@ docs: https://discourse.charmhub.io/t/3749
 applications:
   admission-webhook:
     charm: admission-webhook
-    channel: latest/beta
+    channel: 1.8/beta
     trust: true
     scale: 1
     _github_repo_name: admission-webhook-operator
   argo-controller:
     charm: argo-controller
-    channel: latest/beta
+    channel: 1.8/beta
     trust: true
     scale: 1
     _github_repo_name: argo-operators
   dex-auth:
     charm: dex-auth
-    channel: latest/beta
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: dex-auth-operator
   istio-ingressgateway:
     charm: istio-gateway
-    channel: latest/beta
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: istio-operators
@@ -30,7 +30,7 @@ applications:
       kind: ingress
   istio-pilot:
     charm: istio-pilot
-    channel: latest/beta
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: istio-operators
@@ -38,19 +38,19 @@ applications:
       default-gateway: kubeflow-gateway
   jupyter-controller:
     charm: jupyter-controller
-    channel: latest/beta
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: notebook-operators
   jupyter-ui:
     charm: jupyter-ui
-    channel: latest/beta
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: notebook-operators
   katib-controller:
     charm: katib-controller
-    channel: latest/beta
+    channel: 1.8/beta
     scale: 1
     _github_repo_name: katib-operators
   katib-db:
@@ -61,19 +61,19 @@ applications:
     constraints: mem=2G
   katib-db-manager:
     charm: katib-db-manager
-    channel: latest/beta
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: katib-operators
   katib-ui:
     charm: katib-ui
-    channel: latest/beta
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: katib-operators
   kfp-api:
     charm: kfp-api
-    channel: latest/edge
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
@@ -85,43 +85,43 @@ applications:
     constraints: mem=2G
   kfp-persistence:
     charm: kfp-persistence
-    channel: latest/edge
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
   kfp-profile-controller:
     charm: kfp-profile-controller
-    channel: latest/edge
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
   kfp-schedwf:
     charm: kfp-schedwf
-    channel: latest/edge
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
   kfp-ui:
     charm: kfp-ui
-    channel: latest/edge
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
   kfp-viewer:
     charm: kfp-viewer
-    channel: latest/edge
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
   kfp-viz:
     charm: kfp-viz
-    channel: latest/edge
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
   knative-eventing:
     charm: knative-eventing
-    channel: latest/beta
+    channel: 1.8/beta
     scale: 1
     trust: true
     options:
@@ -129,13 +129,13 @@ applications:
     _github_repo_name: knative-operators
   knative-operator:
     charm: knative-operator
-    channel: latest/beta
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: knative-operators
   knative-serving:
     charm: knative-serving
-    channel: latest/beta
+    channel: 1.8/beta
     scale: 1
     trust: true
     options:
@@ -145,77 +145,77 @@ applications:
     _github_repo_name: knative-operators
   kserve-controller:
     charm: kserve-controller
-    channel: latest/beta
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: kserve-operators
   kubeflow-dashboard:
     charm: kubeflow-dashboard
-    channel: latest/beta
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: kubeflow-dashboard-operator
   kubeflow-profiles:
     charm: kubeflow-profiles
-    channel: 1.7/edge
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: kubeflow-profiles-operator
   kubeflow-roles:
     charm: kubeflow-roles
-    channel: latest/beta
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: kubeflow-roles-operator
   kubeflow-volumes:
     charm: kubeflow-volumes
-    channel: latest/beta
+    channel: 1.8/beta
     scale: 1
     _github_repo_name: kubeflow-volumes-operator
   metacontroller-operator:
     charm: metacontroller-operator
-    channel: latest/beta
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: metacontroller-operator
   minio:
     charm: minio
-    channel: latest/beta
+    channel: 1.8/beta
     scale: 1
     _github_repo_name: minio-operator
   oidc-gatekeeper:
     charm: oidc-gatekeeper
-    channel: latest/beta
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: oidc-gatekeeper-operator
   pvcviewer-operator:
     charm: pvcviewer-operator
-    channel: latest/beta
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: pvcviewer-operator
   seldon-controller-manager:
     charm: seldon-core
-    channel: latest/edge
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: seldon-core-operator
   tensorboard-controller:
     charm: tensorboard-controller
-    channel: latest/beta
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: kubeflow-tensorboards-operator
   tensorboards-web-app:
     charm: tensorboards-web-app
-    channel: latest/beta
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: kubeflow-tensorboards-operator
   training-operator:
     charm: training-operator
-    channel: latest/beta
+    channel: 1.8/beta
     scale: 1
     trust: true
     _github_repo_name: training-operator


### PR DESCRIPTION
Point all CKF charms to their corresponding 1.8/beta channel. This PR should be merged once the charms are available in the correct track.