### PR TITLE
feat: point kfp charms to 2.0-alpha.7 in 1.7 bundles

### DIFF
--- a/releases/1.7/beta/kubeflow/bundle.yaml
+++ b/releases/1.7/beta/kubeflow/bundle.yaml
@@ -75,7 +75,7 @@ applications:
     _github_repo_name: katib-operators
   kfp-api:
     charm: kfp-api
-    channel: 2.0/beta
+    channel: 2.0-alpha.7/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
@@ -87,32 +87,32 @@ applications:
     constraints: mem=2G
   kfp-persistence:
     charm: kfp-persistence
-    channel: 2.0/beta
+    channel: 2.0-alpha.7/beta
     scale: 1
     _github_repo_name: kfp-operators
   kfp-profile-controller:
     charm: kfp-profile-controller
-    channel: 2.0/beta
+    channel: 2.0-alpha.7/beta
     scale: 1
     _github_repo_name: kfp-operators
   kfp-schedwf:
     charm: kfp-schedwf
-    channel: 2.0/beta
+    channel: 2.0-alpha.7/beta
     scale: 1
     _github_repo_name: kfp-operators
   kfp-ui:
     charm: kfp-ui
-    channel: 2.0/beta
+    channel: 2.0-alpha.7/beta
     scale: 1
     _github_repo_name: kfp-operators
   kfp-viewer:
     charm: kfp-viewer
-    channel: 2.0/beta
+    channel: 2.0-alpha.7/beta
     scale: 1
     _github_repo_name: kfp-operators
   kfp-viz:
     charm: kfp-viz
-    channel: 2.0/beta
+    channel: 2.0-alpha.7/beta
     scale: 1
     _github_repo_name: kfp-operators
   knative-eventing:

--- a/releases/1.7/edge/kubeflow/bundle.yaml
+++ b/releases/1.7/edge/kubeflow/bundle.yaml
@@ -88,11 +88,11 @@ applications:
     _github_repo_branch: track/0.15
   kfp-api:
     charm: kfp-api
-    channel: 2.0/edge
+    channel: 2.0-alpha.7/edge
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
-    _github_repo_branch: track/2.0
+    _github_repo_branch: track/2.0-alpha.7
   kfp-db:
     charm: mysql-k8s
     channel: 8.0/edge
@@ -103,40 +103,40 @@ applications:
     _github_dependency_repo_branch: main
   kfp-persistence:
     charm: kfp-persistence
-    channel: 2.0/edge
+    channel: 2.0-alpha.7/edge
     scale: 1
     _github_repo_name: kfp-operators
-    _github_repo_branch: track/2.0
+    _github_repo_branch: track/2.0-alpha.7
   kfp-profile-controller:
     charm: kfp-profile-controller
-    channel: 2.0/edge
+    channel: 2.0-alpha.7/edge
     scale: 1
     _github_repo_name: kfp-operators
-    _github_repo_branch: track/2.0
+    _github_repo_branch: track/2.0-alpha.7
   kfp-schedwf:
     charm: kfp-schedwf
-    channel: 2.0/edge
+    channel: 2.0-alpha.7/edge
     scale: 1
     _github_repo_name: kfp-operators
-    _github_repo_branch: track/2.0
+    _github_repo_branch: track/2.0-alpha.7
   kfp-ui:
     charm: kfp-ui
-    channel: 2.0/edge
+    channel: 2.0-alpha.7/edge
     scale: 1
     _github_repo_name: kfp-operators
-    _github_repo_branch: track/2.0
+    _github_repo_branch: track/2.0-alpha.7
   kfp-viewer:
     charm: kfp-viewer
-    channel: 2.0/edge
+    channel: 2.0-alpha.7/edge
     scale: 1
     _github_repo_name: kfp-operators
-    _github_repo_branch: track/2.0
+    _github_repo_branch: track/2.0-alpha.7
   kfp-viz:
     charm: kfp-viz
-    channel: 2.0/edge
+    channel: 2.0-alpha.7/edge
     scale: 1
     _github_repo_name: kfp-operators
-    _github_repo_branch: track/2.0
+    _github_repo_branch: track/2.0-alpha.7
   knative-eventing:
     charm: knative-eventing
     channel: 1.8/edge

--- a/releases/1.7/stable/kubeflow/bundle.yaml
+++ b/releases/1.7/stable/kubeflow/bundle.yaml
@@ -88,11 +88,11 @@ applications:
     _github_repo_branch: track/0.15
   kfp-api:
     charm: kfp-api
-    channel: 2.0/stable
+    channel: 2.0-alpha.7/stable
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
-    _github_repo_branch: track/2.0
+    _github_repo_branch: track/2.0-alpha.7
   kfp-db:
     charm: mysql-k8s
     channel: 8.0/stable
@@ -103,40 +103,40 @@ applications:
     _github_dependency_repo_branch: main
   kfp-persistence:
     charm: kfp-persistence
-    channel: 2.0/stable
+    channel: 2.0-alpha.7/stable
     scale: 1
     _github_repo_name: kfp-operators
-    _github_repo_branch: track/2.0
+    _github_repo_branch: track/2.0-alpha.7
   kfp-profile-controller:
     charm: kfp-profile-controller
-    channel: 2.0/stable
+    channel: 2.0-alpha.7/stable
     scale: 1
     _github_repo_name: kfp-operators
-    _github_repo_branch: track/2.0
+    _github_repo_branch: track/2.0-alpha.7
   kfp-schedwf:
     charm: kfp-schedwf
-    channel: 2.0/stable
+    channel: 2.0-alpha.7/stable
     scale: 1
     _github_repo_name: kfp-operators
-    _github_repo_branch: track/2.0
+    _github_repo_branch: track/2.0-alpha.7
   kfp-ui:
     charm: kfp-ui
-    channel: 2.0/stable
+    channel: 2.0-alpha.7/stable
     scale: 1
     _github_repo_name: kfp-operators
-    _github_repo_branch: track/2.0
+    _github_repo_branch: track/2.0-alpha.7
   kfp-viewer:
     charm: kfp-viewer
-    channel: 2.0/stable
+    channel: 2.0-alpha.7/stable
     scale: 1
     _github_repo_name: kfp-operators
-    _github_repo_branch: track/2.0
+    _github_repo_branch: track/2.0-alpha.7
   kfp-viz:
     charm: kfp-viz
-    channel: 2.0/stable
+    channel: 2.0-alpha.7/stable
     scale: 1
     _github_repo_name: kfp-operators
-    _github_repo_branch: track/2.0
+    _github_repo_branch: track/2.0-alpha.7
   knative-eventing:
     charm: knative-eventing
     channel: 1.8/stable


### PR DESCRIPTION
changes the channel of kfp charms from `2.0` to `2.0-alpha.7` in 1.7 bundle definitions to accommodate for the upcoming release.
kfp charms of 1.7 will now point to channel `2.0-alpha.7`, so that kfp charms of 1.8 can point to channel `2.0`.
An announcement on discourse will be made for CKF 1.7 users.