### PR TITLE
chore: add 1.8/edge bundle definition

### DIFF
--- a/releases/1.8/edge/kubeflow/README.md
+++ b/releases/1.8/edge/kubeflow/README.md
@@ -1,0 +1,35 @@
+# Kubeflow Operators
+
+## Introduction
+
+Charmed Kubeflow is a full set of Kubernetes operators to deliver the 30+ applications and services
+that make up the latest version of Kubeflow, for easy operations anywhere, from workstations to
+on-prem, to public cloud and edge.
+
+A charm is a software package that includes an operator together with metadata that supports the
+integration of many operators in a coherent aggregated system.
+
+This technology leverages the Juju Operator Lifecycle Manager to provide day-0 to day-2 operations
+of Kubeflow.
+
+Visit [charmed-kubeflow.io][charmedkf] for more information.
+
+## Install
+
+For any Kubernetes, follow the [installation instructions][install].
+
+## Testing
+
+To deploy this bundle and run tests locally, do the following:
+
+1. Set up Kubernetes, Juju, and deploy Charmed Kubeflow bundle using the [installation guide](https://charmed-kubeflow.io/docs/install).
+
+2. Run the Automated User Acceptance Tests following the [instructions in the README file](https://github.com/canonical/charmed-kubeflow-uats#run-the-tests).
+
+## Documentation
+
+Read the [official documentation][docs].
+
+[charmedkf]: https://charmed-kubeflow.io
+[docs]: https://charmed-kubeflow.io/docs
+[install]: https://charmed-kubeflow.io/docs/install

--- a/releases/1.8/edge/kubeflow/bundle.yaml
+++ b/releases/1.8/edge/kubeflow/bundle.yaml
@@ -8,31 +8,35 @@ applications:
     trust: true
     scale: 1
     _github_repo_name: admission-webhook-operator
-    _github_repo_branch: 1.8/edge
+    _github_repo_branch: track/1.8
   argo-controller:
     charm: argo-controller
     channel: 3.3.10/edge
     trust: true
     scale: 1
     _github_repo_name: argo-operators
+    _github_repo_branch: track/3.3.10
   dex-auth:
     charm: dex-auth
     channel: 2.36/edge
     scale: 1
     trust: true
     _github_repo_name: dex-auth-operator
+    _github_repo_branch: track/2.36
   envoy:
     charm: envoy
     channel: 2.0/edge
     scale: 1
     trust: true
     _github_repo_name: envoy-operator
+    _github_repo_branch: track/2.0
   istio-ingressgateway:
     charm: istio-gateway
     channel: 1.17/edge
     scale: 1
     trust: true
     _github_repo_name: istio-operators
+    _github_repo_branch: track/1.17
     options:
       kind: ingress
   istio-pilot:
@@ -41,6 +45,7 @@ applications:
     scale: 1
     trust: true
     _github_repo_name: istio-operators
+    _github_repo_branch: track/1.17
     options:
       default-gateway: kubeflow-gateway
   jupyter-controller:
@@ -49,17 +54,20 @@ applications:
     scale: 1
     trust: true
     _github_repo_name: notebook-operators
+    _github_repo_branch: track/1.8
   jupyter-ui:
     charm: jupyter-ui
     channel: 1.8/edge
     scale: 1
     trust: true
     _github_repo_name: notebook-operators
+    _github_repo_branch: track/1.8
   katib-controller:
     charm: katib-controller
     channel: 0.16/edge
     scale: 1
     _github_repo_name: katib-operators
+    _github_repo_branch: track/0.16
   katib-db:
     charm: mysql-k8s
     channel: 8.0/stable
@@ -72,18 +80,21 @@ applications:
     scale: 1
     trust: true
     _github_repo_name: katib-operators
+    _github_repo_branch: track/0.16
   katib-ui:
     charm: katib-ui
     channel: 0.16/edge
     scale: 1
     trust: true
     _github_repo_name: katib-operators
+    _github_repo_branch: track/0.16
   kfp-api:
     charm: kfp-api
     channel: 2.0/edge
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
+    _github_repo_branch: track/2.0
   kfp-db:
     charm: mysql-k8s
     channel: 8.0/stable
@@ -96,42 +107,49 @@ applications:
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
+    _github_repo_branch: track/2.0
   kfp-persistence:
     charm: kfp-persistence
     channel: 2.0/edge
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
+    _github_repo_branch: track/2.0
   kfp-profile-controller:
     charm: kfp-profile-controller
     channel: 2.0/edge
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
+    _github_repo_branch: track/2.0
   kfp-schedwf:
     charm: kfp-schedwf
     channel: 2.0/edge
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
+    _github_repo_branch: track/2.0
   kfp-ui:
     charm: kfp-ui
     channel: 2.0/edge
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
+    _github_repo_branch: track/2.0
   kfp-viewer:
     charm: kfp-viewer
     channel: 2.0/edge
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
+    _github_repo_branch: track/2.0
   kfp-viz:
     charm: kfp-viz
     channel: 2.0/edge
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
+    _github_repo_branch: track/2.0
   knative-eventing:
     charm: knative-eventing
     channel: 1.10/edge
@@ -140,12 +158,14 @@ applications:
     options:
       namespace: knative-eventing
     _github_repo_name: knative-operators
+    _github_repo_branch: track/1.10
   knative-operator:
     charm: knative-operator
     channel: 1.10/edge
     scale: 1
     trust: true
     _github_repo_name: knative-operators
+    _github_repo_branch: track/1.10
   knative-serving:
     charm: knative-serving
     channel: 1.10/edge
@@ -156,57 +176,67 @@ applications:
       istio.gateway.namespace: kubeflow
       istio.gateway.name: kubeflow-gateway
     _github_repo_name: knative-operators
+    _github_repo_branch: track/1.10
   kserve-controller:
     charm: kserve-controller
     channel: 0.11/edge
     scale: 1
     trust: true
     _github_repo_name: kserve-operators
+    _github_repo_branch: track/0.11
   kubeflow-dashboard:
     charm: kubeflow-dashboard
     channel: 1.8/edge
     scale: 1
     trust: true
     _github_repo_name: kubeflow-dashboard-operator
+    _github_repo_branch: track/1.8
   kubeflow-profiles:
     charm: kubeflow-profiles
     channel: 1.8/edge
     scale: 1
     trust: true
     _github_repo_name: kubeflow-profiles-operator
+    _github_repo_branch: track/1.8
   kubeflow-roles:
     charm: kubeflow-roles
     channel: 1.8/edge
     scale: 1
     trust: true
     _github_repo_name: kubeflow-roles-operator
+    _github_repo_branch: track/1.8
   kubeflow-volumes:
     charm: kubeflow-volumes
     channel: 1.8/edge
     scale: 1
     _github_repo_name: kubeflow-volumes-operator
+    _github_repo_branch: track/1.8
   metacontroller-operator:
     charm: metacontroller-operator
     channel: 3.0/edge
     scale: 1
     trust: true
     _github_repo_name: metacontroller-operator
+    _github_repo_branch: track/3.0
   mlmd:
     charm: mlmd
     channel: 1.14/edge
     scale: 1
     _github_repo_name: mlmd-operator
+    _github_repo_branch: track/1.14
   minio:
     charm: minio
     channel: ckf-1.8/edge
     scale: 1
     _github_repo_name: minio-operator
+    _github_repo_branch: track/ckf-1.8
   oidc-gatekeeper:
     charm: oidc-gatekeeper
     channel: ckf-1.8/edge
     scale: 1
     trust: true
     _github_repo_name: oidc-gatekeeper-operator
+    _github_repo_branch: track/ckf-1.8
   pvcviewer-operator:
     charm: pvcviewer-operator
     channel: 1.8/edge
@@ -214,30 +244,35 @@ applications:
     trust: true
     series: focal
     _github_repo_name: pvcviewer-operator
+    _github_repo_branch: track/1.8
   seldon-controller-manager:
     charm: seldon-core
     channel: 1.17/edge
     scale: 1
     trust: true
     _github_repo_name: seldon-core-operator
+    _github_repo_branch: track/1.17
   tensorboard-controller:
     charm: tensorboard-controller
     channel: 1.8/edge
     scale: 1
     trust: true
     _github_repo_name: kubeflow-tensorboards-operator
+    _github_repo_branch: track/1.8
   tensorboards-web-app:
     charm: tensorboards-web-app
     channel: 1.8/edge
     scale: 1
     trust: true
     _github_repo_name: kubeflow-tensorboards-operator
+    _github_repo_branch: track/1.8
   training-operator:
     charm: training-operator
     channel: 1.7/edge
     scale: 1
     trust: true
     _github_repo_name: training-operator
+    _github_repo_branch: track/1.7
 relations:
   - [argo-controller, minio]
   - [dex-auth:oidc-client, oidc-gatekeeper:oidc-client]

--- a/releases/1.8/edge/kubeflow/bundle.yaml
+++ b/releases/1.8/edge/kubeflow/bundle.yaml
@@ -1,0 +1,273 @@
+bundle: kubernetes
+name: kubeflow
+docs: https://discourse.charmhub.io/t/3749
+applications:
+  admission-webhook:
+    charm: admission-webhook
+    channel: 1.8/edge
+    trust: true
+    scale: 1
+    _github_repo_name: admission-webhook-operator
+    _github_repo_branch: 1.8/edge
+  argo-controller:
+    charm: argo-controller
+    channel: 3.3.10/edge
+    trust: true
+    scale: 1
+    _github_repo_name: argo-operators
+  dex-auth:
+    charm: dex-auth
+    channel: 2.36/edge
+    scale: 1
+    trust: true
+    _github_repo_name: dex-auth-operator
+  envoy:
+    charm: envoy
+    channel: 2.0/edge
+    scale: 1
+    trust: true
+    _github_repo_name: envoy-operator
+  istio-ingressgateway:
+    charm: istio-gateway
+    channel: 1.17/edge
+    scale: 1
+    trust: true
+    _github_repo_name: istio-operators
+    options:
+      kind: ingress
+  istio-pilot:
+    charm: istio-pilot
+    channel: 1.17/edge
+    scale: 1
+    trust: true
+    _github_repo_name: istio-operators
+    options:
+      default-gateway: kubeflow-gateway
+  jupyter-controller:
+    charm: jupyter-controller
+    channel: 1.8/edge
+    scale: 1
+    trust: true
+    _github_repo_name: notebook-operators
+  jupyter-ui:
+    charm: jupyter-ui
+    channel: 1.8/edge
+    scale: 1
+    trust: true
+    _github_repo_name: notebook-operators
+  katib-controller:
+    charm: katib-controller
+    channel: 1.8/edge
+    scale: 1
+    _github_repo_name: katib-operators
+  katib-db:
+    charm: mysql-k8s
+    channel: 8.0/stable
+    scale: 1
+    trust: true
+    constraints: mem=2G
+  katib-db-manager:
+    charm: katib-db-manager
+    channel: 1.8/edge
+    scale: 1
+    trust: true
+    _github_repo_name: katib-operators
+  katib-ui:
+    charm: katib-ui
+    channel: 0.16/edge
+    scale: 1
+    trust: true
+    _github_repo_name: katib-operators
+  kfp-api:
+    charm: kfp-api
+    channel: 2.0/edge
+    scale: 1
+    trust: true
+    _github_repo_name: kfp-operators
+  kfp-db:
+    charm: mysql-k8s
+    channel: 8.0/stable
+    scale: 1
+    trust: true
+    constraints: mem=2G
+  kfp-metadata-writer:
+    charm: kfp-metadata-writer
+    channel: 2.0/edge
+    scale: 1
+    trust: true
+    _github_repo_name: kfp-operators
+  kfp-persistence:
+    charm: kfp-persistence
+    channel: 2.0/edge
+    scale: 1
+    trust: true
+    _github_repo_name: kfp-operators
+  kfp-profile-controller:
+    charm: kfp-profile-controller
+    channel: 2.0/edge
+    scale: 1
+    trust: true
+    _github_repo_name: kfp-operators
+  kfp-schedwf:
+    charm: kfp-schedwf
+    channel: 2.0/edge
+    scale: 1
+    trust: true
+    _github_repo_name: kfp-operators
+  kfp-ui:
+    charm: kfp-ui
+    channel: 2.0/edge
+    scale: 1
+    trust: true
+    _github_repo_name: kfp-operators
+  kfp-viewer:
+    charm: kfp-viewer
+    channel: 2.0/edge
+    scale: 1
+    trust: true
+    _github_repo_name: kfp-operators
+  kfp-viz:
+    charm: kfp-viz
+    channel: 2.0/edge
+    scale: 1
+    trust: true
+    _github_repo_name: kfp-operators
+  knative-eventing:
+    charm: knative-eventing
+    channel: 1.10/edge
+    scale: 1
+    trust: true
+    options:
+      namespace: knative-eventing
+    _github_repo_name: knative-operators
+  knative-operator:
+    charm: knative-operator
+    channel: 1.10/edge
+    scale: 1
+    trust: true
+    _github_repo_name: knative-operators
+  knative-serving:
+    charm: knative-serving
+    channel: 1.10/edge
+    scale: 1
+    trust: true
+    options:
+      namespace: knative-serving
+      istio.gateway.namespace: kubeflow
+      istio.gateway.name: kubeflow-gateway
+    _github_repo_name: knative-operators
+  kserve-controller:
+    charm: kserve-controller
+    channel: 1.8/edge
+    scale: 1
+    trust: true
+    _github_repo_name: kserve-operators
+  kubeflow-dashboard:
+    charm: kubeflow-dashboard
+    channel: 1.8/edge
+    scale: 1
+    trust: true
+    _github_repo_name: kubeflow-dashboard-operator
+  kubeflow-profiles:
+    charm: kubeflow-profiles
+    channel: 1.8/edge
+    scale: 1
+    trust: true
+    _github_repo_name: kubeflow-profiles-operator
+  kubeflow-roles:
+    charm: kubeflow-roles
+    channel: 1.8/edge
+    scale: 1
+    trust: true
+    _github_repo_name: kubeflow-roles-operator
+  kubeflow-volumes:
+    charm: kubeflow-volumes
+    channel: 1.8/edge
+    scale: 1
+    _github_repo_name: kubeflow-volumes-operator
+  metacontroller-operator:
+    charm: metacontroller-operator
+    channel: 3.0/edge
+    scale: 1
+    trust: true
+    _github_repo_name: metacontroller-operator
+  mlmd:
+    charm: mlmd
+    channel: 1.14/edge
+    scale: 1
+    _github_repo_name: mlmd-operator
+  minio:
+    charm: minio
+    channel: ckf-1.8/edge
+    scale: 1
+    _github_repo_name: minio-operator
+  oidc-gatekeeper:
+    charm: oidc-gatekeeper
+    channel: ckf-1.8/edge
+    scale: 1
+    trust: true
+    _github_repo_name: oidc-gatekeeper-operator
+  pvcviewer-operator:
+    charm: pvcviewer-operator
+    channel: 1.8/edge
+    scale: 1
+    trust: true
+    series: focal
+    _github_repo_name: pvcviewer-operator
+  seldon-controller-manager:
+    charm: seldon-core
+    channel: 1.17/edge
+    scale: 1
+    trust: true
+    _github_repo_name: seldon-core-operator
+  tensorboard-controller:
+    charm: tensorboard-controller
+    channel: 1.8/edge
+    scale: 1
+    trust: true
+    _github_repo_name: kubeflow-tensorboards-operator
+  tensorboards-web-app:
+    charm: tensorboards-web-app
+    channel: 1.8/edge
+    scale: 1
+    trust: true
+    _github_repo_name: kubeflow-tensorboards-operator
+  training-operator:
+    charm: training-operator
+    channel: 1.7/edge
+    scale: 1
+    trust: true
+    _github_repo_name: training-operator
+relations:
+  - [argo-controller, minio]
+  - [dex-auth:oidc-client, oidc-gatekeeper:oidc-client]
+  - [istio-pilot:ingress, dex-auth:ingress]
+  - [istio-pilot:ingress, envoy:ingress]
+  - [istio-pilot:ingress, jupyter-ui:ingress]
+  - [istio-pilot:ingress, katib-ui:ingress]
+  - [istio-pilot:ingress, kfp-ui:ingress]
+  - [istio-pilot:ingress, kubeflow-dashboard:ingress]
+  - [istio-pilot:ingress, kubeflow-volumes:ingress]
+  - [istio-pilot:ingress, oidc-gatekeeper:ingress]
+  - [istio-pilot:ingress-auth, oidc-gatekeeper:ingress-auth]
+  - [istio-pilot:istio-pilot, istio-ingressgateway:istio-pilot]
+  - [istio-pilot:ingress, tensorboards-web-app:ingress]
+  - [istio-pilot:gateway-info, tensorboard-controller:gateway-info]
+  - [katib-db-manager:relational-db, katib-db:database]
+  - [kfp-api:relational-db, kfp-db:database]
+  - [kfp-api:kfp-api, kfp-persistence:kfp-api]
+  - [kfp-api:kfp-api, kfp-ui:kfp-api]
+  - [kfp-api:kfp-viz, kfp-viz:kfp-viz]
+  - [kfp-api:object-storage, minio:object-storage]
+  - [kfp-profile-controller:object-storage, minio:object-storage]
+  - [kfp-ui:object-storage, minio:object-storage]
+  - [kserve-controller:ingress-gateway, istio-pilot:gateway-info]
+  - [kserve-controller:local-gateway, knative-serving:local-gateway]
+  - [kubeflow-profiles, kubeflow-dashboard]
+  - [kubeflow-dashboard:links, jupyter-ui:dashboard-links]
+  - [kubeflow-dashboard:links, katib-ui:dashboard-links]
+  - [kubeflow-dashboard:links, kfp-ui:dashboard-links]
+  - [kubeflow-dashboard:links, kubeflow-volumes:dashboard-links]
+  - [kubeflow-dashboard:links, tensorboards-web-app:dashboard-links]
+  - [mlmd:grpc, envoy:grpc]
+  - [mlmd:grpc, kfp-metadata-writer:grpc]

--- a/releases/1.8/edge/kubeflow/bundle.yaml
+++ b/releases/1.8/edge/kubeflow/bundle.yaml
@@ -57,7 +57,7 @@ applications:
     _github_repo_name: notebook-operators
   katib-controller:
     charm: katib-controller
-    channel: 1.8/edge
+    channel: 0.16/edge
     scale: 1
     _github_repo_name: katib-operators
   katib-db:
@@ -68,7 +68,7 @@ applications:
     constraints: mem=2G
   katib-db-manager:
     charm: katib-db-manager
-    channel: 1.8/edge
+    channel: 0.16/edge
     scale: 1
     trust: true
     _github_repo_name: katib-operators
@@ -158,7 +158,7 @@ applications:
     _github_repo_name: knative-operators
   kserve-controller:
     charm: kserve-controller
-    channel: 1.8/edge
+    channel: 0.11/edge
     scale: 1
     trust: true
     _github_repo_name: kserve-operators

--- a/releases/1.8/edge/kubeflow/charmcraft.yaml
+++ b/releases/1.8/edge/kubeflow/charmcraft.yaml
@@ -1,0 +1,1 @@
+type: bundle

--- a/tests-bundle/1.8/test_release_1-8.py
+++ b/tests-bundle/1.8/test_release_1-8.py
@@ -23,6 +23,7 @@ async def test_deploy(ops_test: OpsTest, lightkube_client, deploy_cmd):
         'argo-controller',
         'argo-server',
         'dex-auth',
+        'envoy',
         # 'istio-ingressgateway',  # this is expected to wait for OIDC
         # 'istio-pilot',  # this is expected to wait for OIDC
         'jupyter-controller',
@@ -33,6 +34,7 @@ async def test_deploy(ops_test: OpsTest, lightkube_client, deploy_cmd):
         'katib-ui',
         'kfp-api',
         'kfp-db',
+        'kfp-metadata-writer',
         'kfp-persistence',
         'kfp-profile-controller',
         'kfp-schedwf',
@@ -50,6 +52,7 @@ async def test_deploy(ops_test: OpsTest, lightkube_client, deploy_cmd):
         'kubeflow-volumes',
         'metacontroller-operator',
         'minio',
+        'mlmd',
         # 'oidc-gatekeeper',  # this is expected to wait for public-url config
         'seldon-controller-manager',
         # 'tensorboard-controller',  # this is expected to wait for config


### PR DESCRIPTION
This PR adds a bundle definition for CKF 1.8/edge, which includes newer charms like mlmd, envoy, kfp-metadata-writer, and pvcviewer-operator.
All the tracks correspond to the versions that were proposed in https://github.com/canonical/bundle-kubeflow/issues/643.