### PR TITLE
scripts: Update latest/edge to run 1.8 tests

### DIFF
--- a/scripts/get_bundle_test_path.py
+++ b/scripts/get_bundle_test_path.py
@@ -13,8 +13,8 @@ RELEASE_TESTS = {
     "1.8/beta": "./tests-bundle/1.8/",
     "1.8/edge": "./tests-bundle/1.8/",
     "1.8/stable": "./tests-bundle/1.8/",
-    "latest/beta": "./tests-bundle/1.7/",
-    "latest/edge": "./tests-bundle/1.7/",
+    "latest/beta": "./tests-bundle/1.8/",
+    "latest/edge": "./tests-bundle/1.8/",
 }
 
 


### PR DESCRIPTION
Update scripts to return test path for 1.8 (`./tests-bundle/1.8/`) when the release is `latest/edge`.