### PR TITLE
feat: Enable tests/integration to be able to run 1.7 and 1.8

### DIFF
--- a/.github/workflows/deploy-eks.yaml
+++ b/.github/workflows/deploy-eks.yaml
@@ -63,7 +63,7 @@ jobs:
       
       - name: Test bundle deployment
         run: |
-          tox -vve test_bundle_deployment -- --model kubeflow --keep-models -vv -s
+          tox -vve test_bundle_deployment-1.7 -- --model kubeflow --keep-models -vv -s
       
       # On failure, capture debugging resources
       - name: Get juju status

--- a/tests/integration/test_bundle_deployment.py
+++ b/tests/integration/test_bundle_deployment.py
@@ -1,5 +1,6 @@
 import subprocess
 import json
+import os
 
 import aiohttp
 import lightkube
@@ -8,7 +9,6 @@ import requests
 from pytest_operator.plugin import OpsTest
 from lightkube.resources.core_v1 import Service
 
-BUNDLE_PATH = "./releases/1.7/edge/kubeflow/bundle.yaml"
 BUNDLE_NAME = "kubeflow"
 
 @pytest.fixture()
@@ -16,10 +16,14 @@ def lightkube_client() -> lightkube.Client:
     client = lightkube.Client(field_manager=BUNDLE_NAME)
     return client
 
+@pytest.fixture
+def bundle_path() -> str:
+    return os.environ.get("BUNDLE_PATH").replace("\"", "")
+
 class TestCharm:
     @pytest.mark.abort_on_fail
-    async def test_bundle_deployment_works(self, ops_test: OpsTest, lightkube_client):
-        subprocess.Popen(["juju", "deploy", f"{BUNDLE_PATH}", "--trust"])
+    async def test_bundle_deployment_works(self, ops_test: OpsTest, lightkube_client, bundle_path):
+        subprocess.Popen(["juju", "deploy", bundle_path, "--trust"])
 
         await ops_test.model.wait_for_idle(
             apps=["istio-ingressgateway"],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = lint, fmt, tests, full_bundle_tests, test_bundle_1.7, test_selenium_1.7, {test_bundle_deployment}-{1.7,1.8}
+envlist = lint, fmt, tests, full_bundle_tests, test_bundle_1.7, test_selenium_1.7, {test_bundle_deployment}-{1.7,1.8,latest}
 
 [vars]
 releases_test_path = {toxinidir}/tests-bundle/
@@ -80,12 +80,13 @@ deps =
   -r {[vars]releases_test_path}/1.7/requirements.txt
 description = Test bundles
 
-[testenv:test_bundle_deployment-{1.7,1.8}]
+[testenv:test_bundle_deployment-{1.7,1.8,latest}]
 commands =
     pytest -v --tb native --asyncio-mode=auto {[vars]test_path}/integration/test_bundle_deployment.py --keep-models --log-cli-level=INFO -s {posargs}
 setenv =
     1.7: BUNDLE_PATH = "./releases/1.7/stable/kubeflow/bundle.yaml"
     1.8: BUNDLE_PATH = "./releases/1.8/stable/kubeflow/bundle.yaml"
+    latest: BUNDLE_PATH = "./releases/latest/edge/bundle.yaml"
 deps = 
     aiohttp
     lightkube
@@ -94,4 +95,5 @@ deps =
     ops>=2.3.0
     1.7: juju<3.0.0
     1.8: juju<4.0.0
+    latest: juju<4.0.0
 description = Test bundle deployment

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = upgrade
+envlist = lint, fmt, tests, full_bundle_tests, test_bundle_1.7, test_selenium_1.7, {test_bundle_deployment}-{1.7,1.8}
 
 [vars]
 releases_test_path = {toxinidir}/tests-bundle/
@@ -80,14 +80,18 @@ deps =
   -r {[vars]releases_test_path}/1.7/requirements.txt
 description = Test bundles
 
-[testenv:test_bundle_deployment]
+[testenv:test_bundle_deployment-{1.7,1.8}]
 commands =
     pytest -v --tb native --asyncio-mode=auto {[vars]test_path}/integration/test_bundle_deployment.py --keep-models --log-cli-level=INFO -s {posargs}
+setenv =
+    1.7: BUNDLE_PATH = "./releases/1.7/stable/kubeflow/bundle.yaml"
+    1.8: BUNDLE_PATH = "./releases/1.8/stable/kubeflow/bundle.yaml"
 deps = 
     aiohttp
     lightkube
     pytest-operator
     tenacity
     ops>=2.3.0
-    juju==2.9.43
+    1.7: juju<3.0.0
+    1.8: juju<4.0.0
 description = Test bundle deployment


### PR DESCRIPTION
- Enable tests/integration to be able to run [last two supported versions](https://charmed-kubeflow.io/docs/supported-versions) (1.7 and 1.8). Details in the issue
- Adjust `deploy-eks.yaml` tox command to keep the workflow from testing.
This switches deploying from `edge` to `stable` since we were deploying `edge` 
due to https://github.com/canonical/mysql-k8s-operator/issues/239.

Closes #800