### PR TITLE
fix(ci): Update uats environment used in full-bundle-tests.yaml

### DIFF
--- a/.github/workflows/full-bundle-tests.yaml
+++ b/.github/workflows/full-bundle-tests.yaml
@@ -160,7 +160,7 @@ jobs:
       - name: Run UATs
         run: |
           eval "$(pyenv init -)"
-          sg microk8s -c "tox -c ~/charmed-kubeflow-uats/ -e kubeflow"
+          sg microk8s -c "tox -c ~/charmed-kubeflow-uats/ -e kubeflow-local"
 
       - name: Save debug artifacts
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main


### PR DESCRIPTION
Update UATs environment used in `full-bundle-tests.yaml` used after changes in https://github.com/canonical/charmed-kubeflow-uats/pull/67.