### PR TITLE
chore: trust mlmd due to refactor

### DIFF
--- a/releases/latest/edge/bundle.yaml
+++ b/releases/latest/edge/bundle.yaml
@@ -229,6 +229,7 @@ applications:
     charm: mlmd
     channel: latest/edge
     scale: 1
+    trust: true
     _github_repo_name: mlmd-operator
     _github_repo_branch: main
   minio:


### PR DESCRIPTION
mlmd was recently refactored to use the sidecar pattern, which now requires this charm to be trusted as it applies k8s resources.