### PR TITLE
ci(aks): bump k8s version to 1.28

### DIFF
--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
     env:
       AZURE_CORE_OUTPUT: none
-      K8S_VERSION: ${{ inputs.k8s_version || fromJSON('{"1.8":"1.26", "latest":"1.26"}')[matrix.bundle_version] }}
+      K8S_VERSION: ${{ inputs.k8s_version || fromJSON('{"1.8":"1.28", "latest":"1.28"}')[matrix.bundle_version] }}
       JUJU_VERSION: ${{ fromJSON('{"1.8":"3.5","latest":"3.5"}')[ matrix.bundle_version ] }}
       UATS_BRANCH: ${{ inputs.uats_branch || fromJSON('{"1.8":"main", "latest":"main"}')[matrix.bundle_version] }}
       PYTHON_VERSION: "3.8"


### PR DESCRIPTION
Example run https://github.com/canonical/bundle-kubeflow/actions/runs/9004529983.

Closes #891 

EDIT:
Katib UAT fails but it failed previously as well #893
Training-operator UAT starts to failing after bumping k8s version #894