### PR TITLE
fix: add github dependency attributes to mysql charm in 1.8 bundle

### DIFF
--- a/releases/1.8/beta/kubeflow/bundle.yaml
+++ b/releases/1.8/beta/kubeflow/bundle.yaml
@@ -74,6 +74,8 @@ applications:
     scale: 1
     trust: true
     constraints: mem=2G
+    _github_dependency_repo_name: mysql-k8s-operator
+    _github_dependency_repo_branch: main
   katib-db-manager:
     charm: katib-db-manager
     channel: 0.16/beta
@@ -101,6 +103,8 @@ applications:
     scale: 1
     trust: true
     constraints: mem=2G
+    _github_dependency_repo_name: mysql-k8s-operator
+    _github_dependency_repo_branch: main
   kfp-metadata-writer:
     charm: kfp-metadata-writer
     channel: 2.0/beta

--- a/releases/1.8/edge/kubeflow/bundle.yaml
+++ b/releases/1.8/edge/kubeflow/bundle.yaml
@@ -74,6 +74,8 @@ applications:
     scale: 1
     trust: true
     constraints: mem=2G
+    _github_dependency_repo_name: mysql-k8s-operator
+    _github_dependency_repo_branch: main
   katib-db-manager:
     charm: katib-db-manager
     channel: 0.16/edge
@@ -101,6 +103,8 @@ applications:
     scale: 1
     trust: true
     constraints: mem=2G
+    _github_dependency_repo_name: mysql-k8s-operator
+    _github_dependency_repo_branch: main
   kfp-metadata-writer:
     charm: kfp-metadata-writer
     channel: 2.0/edge

--- a/releases/1.8/stable/kubeflow/bundle.yaml
+++ b/releases/1.8/stable/kubeflow/bundle.yaml
@@ -74,6 +74,8 @@ applications:
     scale: 1
     trust: true
     constraints: mem=2G
+    _github_dependency_repo_name: mysql-k8s-operator
+    _github_dependency_repo_branch: main
   katib-db-manager:
     charm: katib-db-manager
     channel: 0.16/stable
@@ -101,6 +103,8 @@ applications:
     scale: 1
     trust: true
     constraints: mem=2G
+    _github_dependency_repo_name: mysql-k8s-operator
+    _github_dependency_repo_branch: main
   kfp-metadata-writer:
     charm: kfp-metadata-writer
     channel: 2.0/stable


### PR DESCRIPTION
adds the `_github_dependency_repo_name` and `_github_dependency_repo_branch` attributes to `mysql-k8s-operator` charm in the 1.8 bundle yaml.
This is needed for airgapped, so that the `get-all-images.sh` script can get the image for the mysql charm, as similarly done for the [1.7 bundle](https://github.com/canonical/bundle-kubeflow/blob/main/releases/1.7/stable/kubeflow/bundle.yaml#L73C1-L74C41).
Related to #889.