### PR TITLE
fix: update the airgap scripts to work with 1.8

### DIFF
--- a/scripts/airgapped/prerequisites.sh
+++ b/scripts/airgapped/prerequisites.sh
@@ -7,11 +7,14 @@ echo "Installing dependencies..."
 pip3 install -r $SCRIPT_DIR/requirements.txt
 sudo apt update
 
+# Install and Setup Docker
+# we don't do `newgrp docker` here so not to open a new bash session
+# so that the rest of the scripts continue to execute.
+# See in the README.md instructions for the docker user changes to take effect.
 echo "Installing Docker"
 sudo snap install docker
-sudo addgroup --system docker
-sudo adduser $USER docker
-newgrp docker
+sudo groupadd docker
+sudo usermod -aG docker $USER
 sudo snap disable docker
 sudo snap enable docker
 

--- a/scripts/airgapped/prerequisites.sh
+++ b/scripts/airgapped/prerequisites.sh
@@ -10,7 +10,7 @@ sudo apt update
 # Install and Setup Docker
 # we don't do `newgrp docker` here so not to open a new bash session
 # so that the rest of the scripts continue to execute.
-# See in the README.md instructions for the docker user changes to take effect.
+# See in the tests/airgapped README.md instructions for the docker user changes to take effect.
 echo "Installing Docker"
 sudo snap install docker
 sudo groupadd docker

--- a/scripts/airgapped/prerequisites.sh
+++ b/scripts/airgapped/prerequisites.sh
@@ -9,8 +9,9 @@ sudo apt update
 
 echo "Installing Docker"
 sudo snap install docker
-sudo groupadd docker
-sudo usermod -aG docker $USER
+sudo addgroup --system docker
+sudo adduser $USER docker
+newgrp docker
 sudo snap disable docker
 sudo snap enable docker
 

--- a/scripts/airgapped/requirements.txt
+++ b/scripts/airgapped/requirements.txt
@@ -1,2 +1,4 @@
 docker
+#FIXME: remove requests pin when https://github.com/docker/docker-py/issues/3256 is solved 
+requests<2.32.0
 PyYAML

--- a/tests/airgapped/README.md
+++ b/tests/airgapped/README.md
@@ -17,8 +17,8 @@ We've prepared some scripts for setting up the environment
 ./tests/airgapped/setup/setup.sh
 ```
 
-We've observed that in almost all cases we needed to reboot to be able to
-run docker as sudo and the lxc container to, initially, have network access.
+Make sure to reboot your machine after running the setup scripts to be able to
+run docker commands and the lxc container to, initially, have network access.
 
 ## Running the tests
 

--- a/tests/airgapped/ckf.sh
+++ b/tests/airgapped/ckf.sh
@@ -37,9 +37,7 @@ function create_charms_tar() {
   fi
 
   python3 scripts/airgapped/save-charms-to-tar.py \
-      $BUNDLE_PATH \
-      --zip-all \
-      --delete-afterwards
+      $BUNDLE_PATH
 }
 
 function copy_tars_to_airgapped_env() {
@@ -67,8 +65,9 @@ function install_juju() {
   juju_channel="$2"
 
   lxc exec "$container" -- bash -c "
-    snap install juju --channel ${juju_channel} --classic
-    juju bootstrap microk8s
+    snap install juju --channel ${juju_channel}
+    sudo mkdir -p ~/.local/share/juju
+    sudo juju bootstrap microk8s
   "
 
 }

--- a/tests/airgapped/registry.sh
+++ b/tests/airgapped/registry.sh
@@ -31,8 +31,8 @@ function push_juju_images_to_registry() {
   local NAME=$1
 
   lxc exec "$NAME" -- bash -c "
-    microk8s ctr images pull docker.io/jujusolutions/charm-base:ubuntu-20.04
-    microk8s ctr images pull docker.io/jujusolutions/charm-base:ubuntu-22.04
+    sudo microk8s ctr images pull docker.io/jujusolutions/charm-base:ubuntu-20.04
+    sudo microk8s ctr images pull docker.io/jujusolutions/charm-base:ubuntu-22.04
   "
 }
 

--- a/tests/airgapped/setup/prerequisites.sh
+++ b/tests/airgapped/setup/prerequisites.sh
@@ -2,7 +2,7 @@ JUJU_CHANNEL="${JUJU_CHANNEL:-2.9/stable}"
 
 echo "Installing pip"
 sudo apt update
-sudo apt install python3-pip
+sudo apt -y install python3-pip
 
 echo "Installing Juju"
 sudo snap install juju --channel=$JUJU_CHANNEL --classic

--- a/tests/airgapped/setup/setup.sh
+++ b/tests/airgapped/setup/setup.sh
@@ -2,6 +2,8 @@
 set -xe
 
 cat tests/airgapped/lxd.profile | lxd init --preseed
+sudo apt-get update
+sudo apt-get -y install python3-pip
 pip3 install -r scripts/airgapped/requirements.txt
 
 ./scripts/airgapped/prerequisites.sh

--- a/tests/airgapped/setup/setup.sh
+++ b/tests/airgapped/setup/setup.sh
@@ -2,10 +2,9 @@
 set -xe
 
 cat tests/airgapped/lxd.profile | lxd init --preseed
-sudo apt-get update
-sudo apt-get -y install python3-pip
-pip3 install -r scripts/airgapped/requirements.txt
 
-./scripts/airgapped/prerequisites.sh
 ./tests/airgapped/setup/prerequisites.sh
+./scripts/airgapped/prerequisites.sh
 ./tests/airgapped/setup/lxd-docker-networking.sh
+
+echo "Setup completed. Reboot your machine before running the tests for the docker commands to run without sudo."


### PR DESCRIPTION
## Description
Some changes to the airgapped script to use it for testing CKF 1.8
part of #889 

## Summary
* use `sudo` to run microk8s commands, this is needed for strict microk8s
* pin `requests` dependency version until docker issue is resolved
* use `sudo` with `juju bootstrap microk8s` for strict microk8s
* install `python3-pip` before running `pip3 install`
* remove unrecognized arguments for `save-charms-to-tar.py`