### PR TITLE
chore(latest): Add katib-controller katib-db-manager relation

### DIFF
--- a/releases/latest/edge/bundle.yaml
+++ b/releases/latest/edge/bundle.yaml
@@ -297,6 +297,7 @@ relations:
   - [istio-pilot:istio-pilot, istio-ingressgateway:istio-pilot]
   - [istio-pilot:ingress, tensorboards-web-app:ingress]
   - [istio-pilot:gateway-info, tensorboard-controller:gateway-info]
+  - [katib-controller, katib-db-manager]
   - [katib-db-manager:relational-db, katib-db:database]
   - [kfp-api:relational-db, kfp-db:database]
   - [kfp-api:kfp-api, kfp-persistence:kfp-api]


### PR DESCRIPTION
Needed due to canonical/katib-operators#185

Part of #893 fix