### PR TITLE
fix: update airgap deployment script and README.md

### DIFF
--- a/scripts/airgapped/deploy-1.8.sh
+++ b/scripts/airgapped/deploy-1.8.sh
@@ -77,7 +77,7 @@ juju deploy --trust --debug ./$(charm kfp-api) --resource oci-image=$(img api-se
 juju deploy --trust --debug ./$(charm mysql-k8s) kfp-db --constraints="mem=2G" --resource mysql-image=$(img canonical/charmed-mysql)
 juju deploy --trust --debug ./$(charm kfp-metadata-writer) --resource oci-image=$(img metadata-writer)
 juju deploy --trust --debug ./$(charm kfp-persistence) --resource oci-image=$(img persistenceagent)
-juju deploy --trust --debug ./$(charm kfp-profile-controller) --resource oci-image=$(img python:3.11.9-alpine) \
+juju deploy --trust --debug ./$(charm kfp-profile-controller) --resource oci-image=$(img python:3.8-20.04_edge) \
     --config custom_images="visualization_server: '$(img visualization-server)'
 frontend: '$(img frontend)'
 "

--- a/scripts/airgapped/deploy-1.8.sh
+++ b/scripts/airgapped/deploy-1.8.sh
@@ -77,7 +77,7 @@ juju deploy --trust --debug ./$(charm kfp-api) --resource oci-image=$(img api-se
 juju deploy --trust --debug ./$(charm mysql-k8s) kfp-db --constraints="mem=2G" --resource mysql-image=$(img canonical/charmed-mysql)
 juju deploy --trust --debug ./$(charm kfp-metadata-writer) --resource oci-image=$(img metadata-writer)
 juju deploy --trust --debug ./$(charm kfp-persistence) --resource oci-image=$(img persistenceagent)
-juju deploy --trust --debug ./$(charm kfp-profile-controller) --resource oci-image=$(img python:3.8-20.04_edge) \
+juju deploy --trust --debug ./$(charm kfp-profile-controller) --resource oci-image=$(img python:3.8-20.04) \
     --config custom_images="visualization_server: '$(img visualization-server)'
 frontend: '$(img frontend)'
 "

--- a/tests/airgapped/README.md
+++ b/tests/airgapped/README.md
@@ -114,13 +114,8 @@ We've prepared a script for deploying the 1.8 bundle in airgapped:
 bash ./scripts/airgapped/deploy-1.8.sh
 ```
 
-## Configure the dashboard
-1. Configure the public URL
-```
-juju config dex-auth public-url=http://10.64.140.43.nip.io
-juju config oidc-gatekeeper public-url=http://10.64.140.43.nip.io
-```
-2. Configure the username and password
+## Configure authentication and authorization
+Configure the username and password to be able to log in from the dashboard
 ```
 juju config dex-auth static-username=admin
 juju config dex-auth static-password=admin


### PR DESCRIPTION
addresses the comments received in https://github.com/canonical/bundle-kubeflow/pull/947#discussion_r1661248175 :
* updates the image for `kfp-profile-controller` charm in the deployment script, see updated image in the [`track/2.0` branch](https://github.com/canonical/kfp-operators/blob/track/2.0/charms/kfp-profile-controller/metadata.yaml#L14).
* modifies the README.md for testing in airgapped to remove the configure URL step. This was added incorrectly, the URL is already configured with the correct value in the deployment script for [dex-auth](https://github.com/canonical/bundle-kubeflow/blob/main/scripts/airgapped/deploy-1.8.sh#L28) and [oidc](https://github.com/canonical/bundle-kubeflow/blob/main/scripts/airgapped/deploy-1.8.sh#L141).