### PR TITLE
chore: update latest/edge and latest/beta bundles

### DIFF
--- a/releases/latest/beta/bundle.yaml
+++ b/releases/latest/beta/bundle.yaml
@@ -8,24 +8,35 @@ applications:
     trust: true
     scale: 1
     _github_repo_name: admission-webhook-operator
+    _github_repo_branch: main
   argo-controller:
     charm: argo-controller
     channel: latest/beta
     trust: true
     scale: 1
     _github_repo_name: argo-operators
+    _github_repo_branch: main
   dex-auth:
     charm: dex-auth
     channel: latest/beta
     scale: 1
     trust: true
     _github_repo_name: dex-auth-operator
+    _github_repo_branch: main
+  envoy:
+    charm: envoy
+    channel: latest/beta
+    scale: 1
+    trust: true
+    _github_repo_name: envoy-operator
+    _github_repo_branch: main
   istio-ingressgateway:
     charm: istio-gateway
     channel: latest/beta
     scale: 1
     trust: true
     _github_repo_name: istio-operators
+    _github_repo_branch: main
     options:
       kind: ingress
   istio-pilot:
@@ -34,6 +45,7 @@ applications:
     scale: 1
     trust: true
     _github_repo_name: istio-operators
+    _github_repo_branch: main
     options:
       default-gateway: kubeflow-gateway
   jupyter-controller:
@@ -42,83 +54,107 @@ applications:
     scale: 1
     trust: true
     _github_repo_name: notebook-operators
+    _github_repo_branch: main
   jupyter-ui:
     charm: jupyter-ui
     channel: latest/beta
     scale: 1
     trust: true
     _github_repo_name: notebook-operators
+    _github_repo_branch: main
   katib-controller:
     charm: katib-controller
     channel: latest/beta
     scale: 1
+    trust: true
     _github_repo_name: katib-operators
+    _github_repo_branch: main
   katib-db:
     charm: mysql-k8s
     channel: 8.0/stable
     scale: 1
     trust: true
     constraints: mem=2G
+    _github_dependency_repo_name: mysql-k8s-operator
+    _github_dependency_repo_branch: main
   katib-db-manager:
     charm: katib-db-manager
     channel: latest/beta
     scale: 1
     trust: true
     _github_repo_name: katib-operators
+    _github_repo_branch: main
   katib-ui:
     charm: katib-ui
     channel: latest/beta
     scale: 1
     trust: true
     _github_repo_name: katib-operators
+    _github_repo_branch: main
   kfp-api:
     charm: kfp-api
-    channel: latest/edge
+    channel: latest/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
+    _github_repo_branch: main
   kfp-db:
     charm: mysql-k8s
     channel: 8.0/stable
     scale: 1
     trust: true
     constraints: mem=2G
+    _github_dependency_repo_name: mysql-k8s-operator
+    _github_dependency_repo_branch: main
+  kfp-metadata-writer:
+    charm: kfp-metadata-writer
+    channel: latest/beta
+    scale: 1
+    trust: true
+    _github_repo_name: kfp-operators
+    _github_repo_branch: main
   kfp-persistence:
     charm: kfp-persistence
-    channel: latest/edge
+    channel: latest/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
+    _github_repo_branch: main
   kfp-profile-controller:
     charm: kfp-profile-controller
-    channel: latest/edge
+    channel: latest/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
+    _github_repo_branch: main
   kfp-schedwf:
     charm: kfp-schedwf
-    channel: latest/edge
+    channel: latest/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
+    _github_repo_branch: main
   kfp-ui:
     charm: kfp-ui
-    channel: latest/edge
+    channel: latest/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
+    _github_repo_branch: main
   kfp-viewer:
     charm: kfp-viewer
-    channel: latest/edge
+    channel: latest/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
+    _github_repo_branch: main
   kfp-viz:
     charm: kfp-viz
-    channel: latest/edge
+    channel: latest/beta
     scale: 1
     trust: true
     _github_repo_name: kfp-operators
+    _github_repo_branch: main
   knative-eventing:
     charm: knative-eventing
     channel: latest/beta
@@ -127,12 +163,14 @@ applications:
     options:
       namespace: knative-eventing
     _github_repo_name: knative-operators
+    _github_repo_branch: main
   knative-operator:
     charm: knative-operator
     channel: latest/beta
     scale: 1
     trust: true
     _github_repo_name: knative-operators
+    _github_repo_branch: main
   knative-serving:
     charm: knative-serving
     channel: latest/beta
@@ -143,82 +181,107 @@ applications:
       istio.gateway.namespace: kubeflow
       istio.gateway.name: kubeflow-gateway
     _github_repo_name: knative-operators
+    _github_repo_branch: main
   kserve-controller:
     charm: kserve-controller
     channel: latest/beta
     scale: 1
     trust: true
+    options:
+      deployment-mode: serverless
     _github_repo_name: kserve-operators
+    _github_repo_branch: main
   kubeflow-dashboard:
     charm: kubeflow-dashboard
     channel: latest/beta
     scale: 1
     trust: true
     _github_repo_name: kubeflow-dashboard-operator
+    _github_repo_branch: main
   kubeflow-profiles:
     charm: kubeflow-profiles
-    channel: 1.7/edge
+    channel: latest/beta
     scale: 1
     trust: true
     _github_repo_name: kubeflow-profiles-operator
+    _github_repo_branch: main
   kubeflow-roles:
     charm: kubeflow-roles
     channel: latest/beta
     scale: 1
     trust: true
     _github_repo_name: kubeflow-roles-operator
+    _github_repo_branch: main
   kubeflow-volumes:
     charm: kubeflow-volumes
     channel: latest/beta
     scale: 1
+    trust: true
     _github_repo_name: kubeflow-volumes-operator
+    _github_repo_branch: main
   metacontroller-operator:
     charm: metacontroller-operator
     channel: latest/beta
     scale: 1
     trust: true
     _github_repo_name: metacontroller-operator
+    _github_repo_branch: main
+  mlmd:
+    charm: mlmd
+    channel: latest/beta
+    scale: 1
+    trust: true
+    _github_repo_name: mlmd-operator
+    _github_repo_branch: main
   minio:
     charm: minio
     channel: latest/beta
     scale: 1
     _github_repo_name: minio-operator
+    _github_repo_branch: main
   oidc-gatekeeper:
     charm: oidc-gatekeeper
     channel: latest/beta
     scale: 1
     trust: true
     _github_repo_name: oidc-gatekeeper-operator
+    _github_repo_branch: main
   pvcviewer-operator:
     charm: pvcviewer-operator
     channel: latest/beta
     scale: 1
     trust: true
+    series: focal
     _github_repo_name: pvcviewer-operator
+    _github_repo_branch: main
   seldon-controller-manager:
     charm: seldon-core
-    channel: latest/edge
+    channel: latest/beta
     scale: 1
     trust: true
     _github_repo_name: seldon-core-operator
+    _github_repo_branch: main
   tensorboard-controller:
     charm: tensorboard-controller
     channel: latest/beta
     scale: 1
     trust: true
     _github_repo_name: kubeflow-tensorboards-operator
+    _github_repo_branch: main
   tensorboards-web-app:
     charm: tensorboards-web-app
     channel: latest/beta
     scale: 1
     trust: true
     _github_repo_name: kubeflow-tensorboards-operator
+    _github_repo_branch: main
   training-operator:
     charm: training-operator
     channel: latest/beta
     scale: 1
     trust: true
     _github_repo_name: training-operator
+    _github_repo_branch: main
 relations:
   - [argo-controller, minio]
   - [dex-auth:oidc-client, oidc-gatekeeper:oidc-client]
@@ -229,10 +292,12 @@ relations:
   - [istio-pilot:ingress, kubeflow-dashboard:ingress]
   - [istio-pilot:ingress, kubeflow-volumes:ingress]
   - [istio-pilot:ingress, oidc-gatekeeper:ingress]
+  - [istio-pilot:ingress, envoy:ingress]
   - [istio-pilot:ingress-auth, oidc-gatekeeper:ingress-auth]
   - [istio-pilot:istio-pilot, istio-ingressgateway:istio-pilot]
   - [istio-pilot:ingress, tensorboards-web-app:ingress]
   - [istio-pilot:gateway-info, tensorboard-controller:gateway-info]
+  - [katib-controller, katib-db-manager]
   - [katib-db-manager:k8s-service-info, katib-controller:k8s-service-info]
   - [katib-db-manager:relational-db, katib-db:database]
   - [kfp-api:relational-db, kfp-db:database]
@@ -250,3 +315,5 @@ relations:
   - [kubeflow-dashboard:links, kfp-ui:dashboard-links]
   - [kubeflow-dashboard:links, kubeflow-volumes:dashboard-links]
   - [kubeflow-dashboard:links, tensorboards-web-app:dashboard-links]
+  - [mlmd:grpc, envoy:grpc]
+  - [mlmd:grpc, kfp-metadata-writer:grpc]

--- a/releases/latest/beta/bundle.yaml
+++ b/releases/latest/beta/bundle.yaml
@@ -233,6 +233,7 @@ relations:
   - [istio-pilot:istio-pilot, istio-ingressgateway:istio-pilot]
   - [istio-pilot:ingress, tensorboards-web-app:ingress]
   - [istio-pilot:gateway-info, tensorboard-controller:gateway-info]
+  - [katib-db-manager:k8s-service-info, katib-controller:k8s-service-info]
   - [katib-db-manager:relational-db, katib-db:database]
   - [kfp-api:relational-db, kfp-db:database]
   - [kfp-api:kfp-api, kfp-persistence:kfp-api]

--- a/releases/latest/edge/bundle.yaml
+++ b/releases/latest/edge/bundle.yaml
@@ -298,6 +298,7 @@ relations:
   - [istio-pilot:ingress, tensorboards-web-app:ingress]
   - [istio-pilot:gateway-info, tensorboard-controller:gateway-info]
   - [katib-controller, katib-db-manager]
+  - [katib-db-manager:k8s-service-info, katib-controller:k8s-service-info]
   - [katib-db-manager:relational-db, katib-db:database]
   - [kfp-api:relational-db, kfp-db:database]
   - [kfp-api:kfp-api, kfp-persistence:kfp-api]


### PR DESCRIPTION
This commit updates the latest bundle definition to match the latest charm changes (e.g. config options, relations, trust, etc.)

Part of #958