### PR TITLE
chore: remove seldon-core-operator and remove dup relation

### DIFF
--- a/releases/latest/beta/bundle.yaml
+++ b/releases/latest/beta/bundle.yaml
@@ -290,7 +290,6 @@ relations:
   - [istio-pilot:istio-pilot, istio-ingressgateway:istio-pilot]
   - [istio-pilot:ingress, tensorboards-web-app:ingress]
   - [istio-pilot:gateway-info, tensorboard-controller:gateway-info]
-  - [katib-controller, katib-db-manager]
   - [katib-db-manager:k8s-service-info, katib-controller:k8s-service-info]
   - [katib-db-manager:relational-db, katib-db:database]
   - [kfp-api:relational-db, kfp-db:database]

--- a/releases/latest/beta/bundle.yaml
+++ b/releases/latest/beta/bundle.yaml
@@ -254,13 +254,6 @@ applications:
     series: focal
     _github_repo_name: pvcviewer-operator
     _github_repo_branch: main
-  seldon-controller-manager:
-    charm: seldon-core
-    channel: latest/beta
-    scale: 1
-    trust: true
-    _github_repo_name: seldon-core-operator
-    _github_repo_branch: main
   tensorboard-controller:
     charm: tensorboard-controller
     channel: latest/beta

--- a/releases/latest/edge/bundle.yaml
+++ b/releases/latest/edge/bundle.yaml
@@ -254,13 +254,6 @@ applications:
     series: focal
     _github_repo_name: pvcviewer-operator
     _github_repo_branch: main
-  seldon-controller-manager:
-    charm: seldon-core
-    channel: latest/edge
-    scale: 1
-    trust: true
-    _github_repo_name: seldon-core-operator
-    _github_repo_branch: main
   tensorboard-controller:
     charm: tensorboard-controller
     channel: latest/edge

--- a/releases/latest/edge/bundle.yaml
+++ b/releases/latest/edge/bundle.yaml
@@ -290,7 +290,6 @@ relations:
   - [istio-pilot:istio-pilot, istio-ingressgateway:istio-pilot]
   - [istio-pilot:ingress, tensorboards-web-app:ingress]
   - [istio-pilot:gateway-info, tensorboard-controller:gateway-info]
-  - [katib-controller, katib-db-manager]
   - [katib-db-manager:k8s-service-info, katib-controller:k8s-service-info]
   - [katib-db-manager:relational-db, katib-db:database]
   - [kfp-api:relational-db, kfp-db:database]


### PR DESCRIPTION
* Starting from CKF 1.9, seldon-core-operator is no longer maintained and should be removed from the bundle definition.
* Remove the katib-db-controller dup relation