### PR TITLE
add dashboard-links relation with training operator

### DIFF
--- a/releases/latest/beta/bundle.yaml
+++ b/releases/latest/beta/bundle.yaml
@@ -307,5 +307,6 @@ relations:
   - [kubeflow-dashboard:links, kfp-ui:dashboard-links]
   - [kubeflow-dashboard:links, kubeflow-volumes:dashboard-links]
   - [kubeflow-dashboard:links, tensorboards-web-app:dashboard-links]
+  - [kubeflow-dashboard:links, training-operator:dashboard-links]
   - [mlmd:grpc, envoy:grpc]
   - [mlmd:grpc, kfp-metadata-writer:grpc]

--- a/releases/latest/edge/bundle.yaml
+++ b/releases/latest/edge/bundle.yaml
@@ -307,5 +307,6 @@ relations:
   - [kubeflow-dashboard:links, kfp-ui:dashboard-links]
   - [kubeflow-dashboard:links, kubeflow-volumes:dashboard-links]
   - [kubeflow-dashboard:links, tensorboards-web-app:dashboard-links]
+  - [kubeflow-dashboard:links, training-operator:dashboard-links]
   - [mlmd:grpc, envoy:grpc]
   - [mlmd:grpc, kfp-metadata-writer:grpc]


### PR DESCRIPTION
adds the missing relation introduced in https://github.com/canonical/training-operator/pull/177