### PR TITLE
chore: add relation for dex-oidc-config

### DIFF
--- a/releases/latest/beta/bundle.yaml
+++ b/releases/latest/beta/bundle.yaml
@@ -277,6 +277,7 @@ applications:
     _github_repo_branch: main
 relations:
   - [argo-controller, minio]
+  - [dex-auth:dex-oidc-config, oidc-gatekeeper:dex-oidc-config]
   - [dex-auth:oidc-client, oidc-gatekeeper:oidc-client]
   - [istio-pilot:ingress, dex-auth:ingress]
   - [istio-pilot:ingress, jupyter-ui:ingress]

--- a/releases/latest/edge/bundle.yaml
+++ b/releases/latest/edge/bundle.yaml
@@ -277,6 +277,7 @@ applications:
     _github_repo_branch: main
 relations:
   - [argo-controller, minio]
+  - [dex-auth:dex-oidc-config, oidc-gatekeeper:dex-oidc-config]
   - [dex-auth:oidc-client, oidc-gatekeeper:oidc-client]
   - [istio-pilot:ingress, dex-auth:ingress]
   - [istio-pilot:ingress, jupyter-ui:ingress]


### PR DESCRIPTION
Add relation between dex-auth and oidc-gatekeeper to share Dex's OIDC configuration.

Merge once all PRs for this feature are completed.

* https://github.com/canonical/dex-auth-operator/pull/211
* https://github.com/canonical/oidc-gatekeeper-operator/pull/163
* https://github.com/canonical/oidc-gatekeeper-operator/pull/164