### PR TITLE
chore: update tox for 1.9 bundle tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -86,7 +86,7 @@ commands =
 setenv =
     1.7: BUNDLE_PATH = "./releases/1.7/stable/kubeflow/bundle.yaml"
     1.8: BUNDLE_PATH = "./releases/1.8/stable/kubeflow/bundle.yaml"
-    1.9: BUNDLE_PATH = "./releases/latest/beta/bundle.yaml"
+    1.9: BUNDLE_PATH = "./releases/1.9/edge/bundle.yaml"
     latest: BUNDLE_PATH = "./releases/latest/edge/bundle.yaml"
 deps = 
     aiohttp


### PR DESCRIPTION
closes #809 

This PR now changes the tox file to point 1.9 tests to `1.9/edge`, it should later be updated to point to `1.9/stable`
In the meantime, we can run the tests from the branch of this PR for `1.9/edge`
Keeping it as draft until we have `1.9/stable` bundle ready