### PR TITLE
chore: point the 1.9 bundle tests to 1.9/stable

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -86,7 +86,7 @@ commands =
 setenv =
     1.7: BUNDLE_PATH = "./releases/1.7/stable/kubeflow/bundle.yaml"
     1.8: BUNDLE_PATH = "./releases/1.8/stable/kubeflow/bundle.yaml"
-    1.9: BUNDLE_PATH = "./releases/latest/beta/bundle.yaml"
+    1.9: BUNDLE_PATH = "./releases/1.9/stable/bundle.yaml"
     latest: BUNDLE_PATH = "./releases/latest/edge/bundle.yaml"
 deps = 
     aiohttp


### PR DESCRIPTION
Since this version of the bundle is now released, the automation should test with the right path to the 1.9/stable bundle.yaml.