### PR TITLE
tests: remove extra relation between oidc and dex

### DIFF
--- a/tests/integration/test_bundle_deployment.py
+++ b/tests/integration/test_bundle_deployment.py
@@ -50,10 +50,6 @@ class TestCharm:
     
             await ops_test.model.applications["dex-auth"].set_config({"public-url": url})
             await ops_test.model.applications["oidc-gatekeeper"].set_config({"public-url": url})
-        else:
-            await ops_test.model.add_relation(
-                "oidc-gatekeeper:dex-oidc-config", f"dex-auth:dex-oidc-config"
-            )
 
         # Wait for the whole bundle to become active and idle
         await ops_test.model.wait_for_idle(


### PR DESCRIPTION
The dex-issuer-config relation between oidc-gateeeker and dex-auth is not needed as the bundle already defines it. Removing it from the test file to avoid issues with juju applying a relation that already exists.