### PR TITLE
tests: use dex-auth svc DNS name as public-url

### DIFF
--- a/tests/integration/test_bundle_deployment.py
+++ b/tests/integration/test_bundle_deployment.py
@@ -47,9 +47,11 @@ class TestCharm:
                 raise_on_error=False,
                 timeout=1500,
             )
+
+            dex_svc_dns_name = "http://dex-auth.kubeflow.svc:5556"
     
-            await ops_test.model.applications["dex-auth"].set_config({"public-url": url})
-            await ops_test.model.applications["oidc-gatekeeper"].set_config({"public-url": url})
+            await ops_test.model.applications["dex-auth"].set_config({"public-url": dex_svc_dns_name})
+            await ops_test.model.applications["oidc-gatekeeper"].set_config({"public-url": dex_svc_dns_name})
 
         # Wait for the whole bundle to become active and idle
         await ops_test.model.wait_for_idle(


### PR DESCRIPTION
For CKF 1.8, dex-auth and oidc-gatekeeper's public-url config option can be set to http://dex-auth.kubeflow.svc:5556, this is because the whole authentication process is done internally in the cluster with dex-auth as an IdP and oidc-gatekeeper as an OIDC client.