### PR TITLE
chore: add 1.9-stable as test reference

### DIFF
--- a/test-reference/versions.json
+++ b/test-reference/versions.json
@@ -22,8 +22,7 @@
     "juju": {
       "current-edge": "3.4/edge",
       "current-stable": "3.4/stable",
-      "future-edge": "3.6/edge",
-      "future-stable": "3.6/stable"
+      "future-beta": "3.6/beta"
     }
   },
   "ckf-1.8-stable-mlflow-2.0-stable": {

--- a/test-reference/versions.json
+++ b/test-reference/versions.json
@@ -1,4 +1,31 @@
 {
+  "ckf-1.9-stable": {
+    "ckf":"1.9/stable",
+    "k8s": {
+      "charmed-kubernetes": {
+        "min-supported": "1.24",
+        "max-supported": "1.30"
+      },
+      "microk8s": {
+        "min-supported": "1.25",
+        "max-supported": "1.30"
+      },
+      "aks": {
+        "min-supported": "1.27",
+        "max-supported": "1.30"
+      },
+      "eks": {
+        "min-supported": "1.24",
+        "max-supported": "1.30"
+      }
+    },
+    "juju": {
+      "current-edge": "3.4/edge",
+      "current-stable": "3.4/stable",
+      "future-edge": "3.6/edge",
+      "future-stable": "3.6/stable"
+    }
+  },
   "ckf-1.8-stable-mlflow-2.0-stable": {
     "ckf":"1.8/stable",
     "mlflow": "2.0/stable",

--- a/test-reference/versions.json
+++ b/test-reference/versions.json
@@ -3,11 +3,11 @@
     "ckf":"1.9/stable",
     "k8s": {
       "charmed-kubernetes": {
-        "min-supported": "1.24",
+        "min-supported": "1.27",
         "max-supported": "1.30"
       },
       "microk8s": {
-        "min-supported": "1.25",
+        "min-supported": "1.27",
         "max-supported": "1.30"
       },
       "aks": {
@@ -15,7 +15,7 @@
         "max-supported": "1.30"
       },
       "eks": {
-        "min-supported": "1.24",
+        "min-supported": "1.27",
         "max-supported": "1.30"
       }
     },


### PR DESCRIPTION
Add CKF 1.9 stable as test reference so SQA can perform testing on all the combinations from the "ckf-1.9-stable" object.