### PR TITLE
ci: Update scanning actions to scan 1.9/stable and drop 1.7

### DIFF
--- a/.github/workflows/scan-images.yaml
+++ b/.github/workflows/scan-images.yaml
@@ -12,8 +12,8 @@ jobs:
       matrix:
         # specfy location of bundle(s) to be scanned
         bundle:
-          - releases/1.7/stable/kubeflow
           - releases/1.8/stable/kubeflow
+          - releases/1.9/stable/kubeflow
           - releases/latest/edge
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
To ensure the scan results are using 1.9