### PR TITLE
Fix the scanning for 1.9

### DIFF
--- a/.github/workflows/scan-images.yaml
+++ b/.github/workflows/scan-images.yaml
@@ -13,7 +13,7 @@ jobs:
         # specfy location of bundle(s) to be scanned
         bundle:
           - releases/1.8/stable/kubeflow
-          - releases/1.9/stable/kubeflow
+          - releases/1.9/stable
           - releases/latest/edge
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
This is a follow-up from https://github.com/canonical/bundle-kubeflow/pull/1027
Part of https://github.com/canonical/bundle-kubeflow/issues/1032
Should be merged after https://github.com/canonical/kubeflow-ci/pull/142

The PR does the following 2:
1. Use the correct path for the 1.9 bundle, as it was slightly different from the other bundles
2. Ensure if the bash script for gathering image fails then the whole step in the GH Action fails, to make it easier to debug and expose the error