### PR TITLE
Handle input not enclosed in quotes in "Deploy to AKS" and "Deploy to EKS" actions

### DIFF
--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -33,6 +33,7 @@ jobs:
           JSON_ARRAY=$(echo "[\"${INPUT_VERSIONS//,/\",\"}\"]")
           
           echo "bundle_versions=${JSON_ARRAY}" >> $GITHUB_OUTPUT
+          echo "bundle_versions=${bundle_versions}"
           
   deploy-ckf-to-aks:
     needs: preprocess-input

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       bundle_version:
-        description: 'Comma-separated list of bundle versions e.g. "1.8","latest". Make sure that the corresponding k8s version is supported by the cloud.'
+        description: 'Comma-separated list of bundle versions e.g. "1.8,1.9,latest". Make sure that the corresponding K8s version is supported by the cloud.'
         default: '1.8,1.9,latest'
         required: true
       k8s_version:
@@ -15,7 +15,7 @@ on:
   schedule:
     - cron: "17 0 * * 2"
 jobs:
-  preprocess:
+  preprocess-input:
     runs-on: ubuntu-22.04
     outputs:
       processed_bundle_versions: ${{ steps.process_bundle_versions.outputs.bundle_versions }}
@@ -23,7 +23,6 @@ jobs:
       - name: Process bundle versions
         id: process_bundle_versions
         run: |
-          # Ensure that bundle_version has a value, fallback to default if not
           if [ -z "${{ github.event.inputs.bundle_version }}" ]; then
             INPUT_VERSIONS="1.8,1.9,latest"
           else
@@ -33,15 +32,14 @@ jobs:
           # Convert the comma-separated values into a JSON array
           JSON_ARRAY=$(echo "[\"${INPUT_VERSIONS//,/\",\"}\"]")
           
-          # Set the JSON array as an output
-          echo "bundle_versions=${JSON_ARRAY}" >> $GITHUB_OUTPUT
+          echo "bundle_versions=${JSON_ARRAY}" >> $GITHUB_ENV
           
   deploy-ckf-to-aks:
-    needs: preprocess
+    needs: preprocess-input
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        bundle_version: ${{ fromJSON(needs.preprocess.outputs.processed_bundle_versions) }}
+        bundle_version: ${{ fromJSON(needs.preprocess-input.outputs.processed_bundle_versions) }}
       fail-fast: false
     env:
       AZURE_CORE_OUTPUT: none

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -3,8 +3,8 @@ on:
   workflow_dispatch:
     inputs:
       bundle_version:
-        description: 'Comma-separated list of bundle versions e.g. 1.8,1.9,latest. Make sure that the corresponding K8s version is supported by the cloud.'
-        default: '1.8,1.9,latest'
+        description: 'Comma-separated list of bundle versions e.g. 1.8, 1.9, latest. Make sure that the corresponding K8s version is supported by the cloud.'
+        default: '1.8, 1.9, latest'
         required: true
       k8s_version:
         description: 'Kubernetes version to be used for the AKS cluster'

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -30,8 +30,7 @@ jobs:
           
       - name: Process bundle versions
         id: process_bundle_versions
-        run: |
-          python scripts/gh-actions/parse_versions.py
+        run: python scripts/gh-actions/parse_versions.py
           
   deploy-ckf-to-aks:
     needs: preprocess-input

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -20,23 +20,18 @@ jobs:
     outputs:
       processed_bundle_versions: ${{ steps.process_bundle_versions.outputs.bundle_versions }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          
       - name: Process bundle versions
         id: process_bundle_versions
         run: |
-          if [ -z "${{ github.event.inputs.bundle_version }}" ]; then
-            INPUT_VERSIONS="1.8,1.9,latest"
-          else
-            INPUT_VERSIONS="${{ github.event.inputs.bundle_version }}"
-            # Also remove whitespace between the entries
-            INPUT_VERSIONS="$(echo "$INPUT_VERSIONS" | tr -d ' ')"
-          fi
-          
-          # Convert the comma-separated values into a JSON array
-          JSON_ARRAY=$(echo "[\"${INPUT_VERSIONS//,/\",\"}\"]")
-          
-          echo "bundle_versions=${JSON_ARRAY}" >> $GITHUB_OUTPUT
-          # Output to the terminal so we can see the final value
-          echo "bundle_versions=${JSON_ARRAY}"
+          python scripts/gh-actions/parse_versions.py
           
   deploy-ckf-to-aks:
     needs: preprocess-input

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -15,11 +15,31 @@ on:
   schedule:
     - cron: "17 0 * * 2"
 jobs:
+  preprocess:
+    runs-on: ubuntu-22.04
+    outputs:
+      processed_bundle_versions: ${{ steps.process_bundle_versions.outputs.bundle_versions }}
+    steps:
+      - name: Process bundle versions
+        id: process_bundle_versions
+        run: |
+          # Ensure that bundle_version has a value, fallback to default if not
+          if [ -z "${{ github.event.inputs.bundle_version }}" ]; then
+            INPUT_VERSIONS="1.8,1.9,latest"
+          else
+            INPUT_VERSIONS="${{ github.event.inputs.bundle_version }}"
+          fi
+          
+          # Convert the comma-separated values into a JSON array
+          JSON_ARRAY=$(echo "[\"${INPUT_VERSIONS//,/\",\"}\"]")
+          
+          # Set the JSON array as an output
+          echo "bundle_versions=${JSON_ARRAY}" >> $GITHUB_OUTPUT
   deploy-ckf-to-aks:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        bundle_version: ${{ fromJSON(format('["{0}"]', join('","', inputs.bundle_version.split(',')))) }}
+        bundle_version: ${{ fromJSON(needs.preprocess.outputs.processed_bundle_versions) }}
       fail-fast: false
     env:
       AZURE_CORE_OUTPUT: none

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       bundle_version:
-        description: 'Comma-separated list of bundle versions e.g. "1.8,1.9,latest". Make sure that the corresponding K8s version is supported by the cloud.'
+        description: 'Comma-separated list of bundle versions e.g. 1.8,1.9,latest. Make sure that the corresponding K8s version is supported by the cloud.'
         default: '1.8,1.9,latest'
         required: true
       k8s_version:
@@ -32,7 +32,7 @@ jobs:
           # Convert the comma-separated values into a JSON array
           JSON_ARRAY=$(echo "[\"${INPUT_VERSIONS//,/\",\"}\"]")
           
-          echo "bundle_versions=${JSON_ARRAY}" >> $GITHUB_ENV
+          echo "bundle_versions=${JSON_ARRAY}" >> $GITHUB_OUTPUT
           
   deploy-ckf-to-aks:
     needs: preprocess-input

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        bundle_version: ${{ fromJSON(format('["{0}"]', join('","', inputs.bundle_version.split(',')))) || '1.8,1.9,latest'}}
+        bundle_version: ${{ fromJSON(format('["{0}"]', join('","', inputs.bundle_version.split(','))) || '1.8,1.9,latest') }}
       fail-fast: false
     env:
       AZURE_CORE_OUTPUT: none

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -33,7 +33,7 @@ jobs:
           JSON_ARRAY=$(echo "[\"${INPUT_VERSIONS//,/\",\"}\"]")
           
           echo "bundle_versions=${JSON_ARRAY}" >> $GITHUB_OUTPUT
-          echo "bundle_versions=${bundle_versions}"
+          echo "bundle_versions=${JSON_ARRAY}"
           
   deploy-ckf-to-aks:
     needs: preprocess-input

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -10,7 +10,7 @@ on:
         description: 'Kubernetes version to be used for the AKS cluster'
         required: false
       uats_branch:
-        description: 'Branch to run the UATs from e.g. main or track/1.8. By default, this is defined by the dependencies.yaml file.'
+        description: 'Branch to run the UATs from e.g. main or track/1.9. By default, this is defined by the dependencies.yaml file.'
         required: false
   schedule:
     - cron: "17 0 * * 2"

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -4,7 +4,7 @@ on:
     inputs:
       bundle_version:
         description: 'Comma-separated list of bundle versions e.g. "1.8","latest". Make sure that the corresponding k8s version is supported by the cloud.'
-        default: '"1.8","1.9","latest"'
+        default: '1.8,1.9,latest'
         required: true
       k8s_version:
         description: 'Kubernetes version to be used for the AKS cluster'
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        bundle_version: ${{ fromJSON(format('[{0}]', inputs.bundle_version || '"1.8","1.9","latest"')) }}
+        bundle_version: ${{ fromJSON(format('["{0}"]', join('","', inputs.bundle_version.split(',')))) || '1.8,1.9,latest'}}
       fail-fast: false
     env:
       AZURE_CORE_OUTPUT: none

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        bundle_version: ${{ fromJSON(format('["{0}"]', join('","', inputs.bundle_version.split(','))) || '1.8,1.9,latest') }}
+        bundle_version: ${{ fromJSON(format('["{0}"]', join('","', inputs.bundle_version.split(',')))) }}
       fail-fast: false
     env:
       AZURE_CORE_OUTPUT: none

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -27,12 +27,15 @@ jobs:
             INPUT_VERSIONS="1.8,1.9,latest"
           else
             INPUT_VERSIONS="${{ github.event.inputs.bundle_version }}"
+            # Also remove whitespace between the entries
+            INPUT_VERSIONS="$(echo "$INPUT_VERSIONS" | tr -d ' ')"
           fi
           
           # Convert the comma-separated values into a JSON array
           JSON_ARRAY=$(echo "[\"${INPUT_VERSIONS//,/\",\"}\"]")
           
           echo "bundle_versions=${JSON_ARRAY}" >> $GITHUB_OUTPUT
+          # Output to the terminal so we can see the final value
           echo "bundle_versions=${JSON_ARRAY}"
           
   deploy-ckf-to-aks:

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -35,7 +35,9 @@ jobs:
           
           # Set the JSON array as an output
           echo "bundle_versions=${JSON_ARRAY}" >> $GITHUB_OUTPUT
+          
   deploy-ckf-to-aks:
+    needs: preprocess
     runs-on: ubuntu-22.04
     strategy:
       matrix:

--- a/.github/workflows/deploy-to-eks.yaml
+++ b/.github/workflows/deploy-to-eks.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch: # This event allows manual triggering from the Github UI
     inputs:
       bundle_version:
-        description: 'Comma-separated list of bundle versions e.g. 1.8,1.9,latest. Make sure that the corresponding k8s version is supported by the cloud.'
+        description: 'Comma-separated list of bundle versions e.g. 1.8,1.9,latest. Make sure that the corresponding K8s version is supported by the cloud.'
         default: '1.8,1.9,latest'
         required: true
       k8s_version:

--- a/.github/workflows/deploy-to-eks.yaml
+++ b/.github/workflows/deploy-to-eks.yaml
@@ -15,7 +15,6 @@ on:
   schedule:
     - cron: "23 0 * * 2"
 jobs:
-  jobs:
   preprocess-input:
     runs-on: ubuntu-22.04
     outputs:
@@ -35,6 +34,7 @@ jobs:
           
           echo "bundle_versions=${JSON_ARRAY}" >> $GITHUB_OUTPUT
   deploy-ckf-to-eks:
+    needs: preprocess-input
     runs-on: ubuntu-22.04
     strategy:
       matrix:

--- a/.github/workflows/deploy-to-eks.yaml
+++ b/.github/workflows/deploy-to-eks.yaml
@@ -27,12 +27,15 @@ jobs:
             INPUT_VERSIONS="1.8,1.9,latest"
           else
             INPUT_VERSIONS="${{ github.event.inputs.bundle_version }}"
+            # Also remove whitespace between the entries
+            INPUT_VERSIONS="$(echo "$INPUT_VERSIONS" | tr -d ' ')"
           fi
           
           # Convert the comma-separated values into a JSON array
           JSON_ARRAY=$(echo "[\"${INPUT_VERSIONS//,/\",\"}\"]")
           
           echo "bundle_versions=${JSON_ARRAY}" >> $GITHUB_OUTPUT
+          # Output to the terminal so we can see the final value
           echo "bundle_versions=${JSON_ARRAY}"
           
   deploy-ckf-to-eks:

--- a/.github/workflows/deploy-to-eks.yaml
+++ b/.github/workflows/deploy-to-eks.yaml
@@ -33,7 +33,7 @@ jobs:
           JSON_ARRAY=$(echo "[\"${INPUT_VERSIONS//,/\",\"}\"]")
           
           echo "bundle_versions=${JSON_ARRAY}" >> $GITHUB_OUTPUT
-          echo "bundle_versions=${bundle_versions}"
+          echo "bundle_versions=${JSON_ARRAY}"
           
   deploy-ckf-to-eks:
     needs: preprocess-input

--- a/.github/workflows/deploy-to-eks.yaml
+++ b/.github/workflows/deploy-to-eks.yaml
@@ -20,23 +20,17 @@ jobs:
     outputs:
       processed_bundle_versions: ${{ steps.process_bundle_versions.outputs.bundle_versions }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          
       - name: Process bundle versions
         id: process_bundle_versions
-        run: |
-          if [ -z "${{ github.event.inputs.bundle_version }}" ]; then
-            INPUT_VERSIONS="1.8,1.9,latest"
-          else
-            INPUT_VERSIONS="${{ github.event.inputs.bundle_version }}"
-            # Also remove whitespace between the entries
-            INPUT_VERSIONS="$(echo "$INPUT_VERSIONS" | tr -d ' ')"
-          fi
-          
-          # Convert the comma-separated values into a JSON array
-          JSON_ARRAY=$(echo "[\"${INPUT_VERSIONS//,/\",\"}\"]")
-          
-          echo "bundle_versions=${JSON_ARRAY}" >> $GITHUB_OUTPUT
-          # Output to the terminal so we can see the final value
-          echo "bundle_versions=${JSON_ARRAY}"
+        run: python scripts/gh-actions/parse_versions.py
           
   deploy-ckf-to-eks:
     needs: preprocess-input

--- a/.github/workflows/deploy-to-eks.yaml
+++ b/.github/workflows/deploy-to-eks.yaml
@@ -33,6 +33,8 @@ jobs:
           JSON_ARRAY=$(echo "[\"${INPUT_VERSIONS//,/\",\"}\"]")
           
           echo "bundle_versions=${JSON_ARRAY}" >> $GITHUB_OUTPUT
+          echo "bundle_versions=${bundle_versions}"
+          
   deploy-ckf-to-eks:
     needs: preprocess-input
     runs-on: ubuntu-22.04

--- a/.github/workflows/deploy-to-eks.yaml
+++ b/.github/workflows/deploy-to-eks.yaml
@@ -3,8 +3,8 @@ on:
   workflow_dispatch: # This event allows manual triggering from the Github UI
     inputs:
       bundle_version:
-        description: 'Comma-separated list of bundle versions e.g. "1.9","latest". Make sure that the corresponding k8s version is supported by the cloud.'
-        default: '"1.8","1.9","latest"'
+        description: 'Comma-separated list of bundle versions e.g. 1.8,1.9,latest. Make sure that the corresponding k8s version is supported by the cloud.'
+        default: '1.8,1.9,latest'
         required: true
       k8s_version:
         description: 'Kubernetes version to be used for the AKS cluster'
@@ -15,11 +15,30 @@ on:
   schedule:
     - cron: "23 0 * * 2"
 jobs:
+  jobs:
+  preprocess-input:
+    runs-on: ubuntu-22.04
+    outputs:
+      processed_bundle_versions: ${{ steps.process_bundle_versions.outputs.bundle_versions }}
+    steps:
+      - name: Process bundle versions
+        id: process_bundle_versions
+        run: |
+          if [ -z "${{ github.event.inputs.bundle_version }}" ]; then
+            INPUT_VERSIONS="1.8,1.9,latest"
+          else
+            INPUT_VERSIONS="${{ github.event.inputs.bundle_version }}"
+          fi
+          
+          # Convert the comma-separated values into a JSON array
+          JSON_ARRAY=$(echo "[\"${INPUT_VERSIONS//,/\",\"}\"]")
+          
+          echo "bundle_versions=${JSON_ARRAY}" >> $GITHUB_OUTPUT
   deploy-ckf-to-eks:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        bundle_version: ${{ fromJSON(format('[{0}]', inputs.bundle_version || '"1.8","1.9","latest"')) }}
+        bundle_version: ${{ fromJSON(needs.preprocess-input.outputs.processed_bundle_versions) }}
       fail-fast: false
     env:
       PYTHON_VERSION: "3.8"

--- a/.github/workflows/deploy-to-eks.yaml
+++ b/.github/workflows/deploy-to-eks.yaml
@@ -3,8 +3,8 @@ on:
   workflow_dispatch: # This event allows manual triggering from the Github UI
     inputs:
       bundle_version:
-        description: 'Comma-separated list of bundle versions e.g. 1.8,1.9,latest. Make sure that the corresponding K8s version is supported by the cloud.'
-        default: '1.8,1.9,latest'
+        description: 'Comma-separated list of bundle versions e.g. 1.8, 1.9, latest. Make sure that the corresponding K8s version is supported by the cloud.'
+        default: '1.8, 1.9, latest'
         required: true
       k8s_version:
         description: 'Kubernetes version to be used for the AKS cluster'

--- a/scripts/gh-actions/parse_versions.py
+++ b/scripts/gh-actions/parse_versions.py
@@ -2,8 +2,9 @@ import os
 import sys
 import json
 
+# Parse the versions given as a comma-separated list and return a JSON array
 def parse_versions(input_versions):
-    # Default version string if input is empty
+    # Default version string if the input is empty
     if not input_versions:
         input_versions = "1.8,1.9,latest"
     else:
@@ -15,13 +16,10 @@ def parse_versions(input_versions):
     return json_array
 
 if __name__ == "__main__":
-    # Read the input version from the environment variable
+    # Read the input of the Github Action from the environment variable
     input_versions = os.getenv('INPUT_BUNDLE_VERSION', '')
-    # Parse the versions
     json_array = parse_versions(input_versions)
-    # Output the result to GitHub Actions
     print(f"bundle_versions={json_array}")
-    # Write to GitHub Actions output
     with open(os.environ['GITHUB_OUTPUT'], 'a') as output_file:
         output_file.write(f"bundle_versions={json_array}\n")
 

--- a/scripts/gh-actions/parse_versions.py
+++ b/scripts/gh-actions/parse_versions.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import json
+
+def parse_versions(input_versions):
+    # Default version string if input is empty
+    if not input_versions:
+        input_versions = "1.8,1.9,latest"
+    else:
+        # Remove whitespace between entries
+        input_versions = input_versions.replace(" ", "")
+    
+    # Convert to JSON array
+    json_array = json.dumps(input_versions.split(","))
+    return json_array
+
+if __name__ == "__main__":
+    # Read the input version from the environment variable
+    input_versions = os.getenv('INPUT_BUNDLE_VERSION', '')
+    # Parse the versions
+    json_array = parse_versions(input_versions)
+    # Output the result to GitHub Actions
+    print(f"bundle_versions={json_array}")
+    # Write to GitHub Actions output
+    with open(os.environ['GITHUB_OUTPUT'], 'a') as output_file:
+        output_file.write(f"bundle_versions={json_array}\n")
+


### PR DESCRIPTION
Closes #1034 

This PR updates the `deploy-to-aks.yaml` and `deploy-to-eks.yaml` scripts to be able to handle values not enclosed in quotes. This is achieved by adding a `preprocess-input` job that processes the input to add quote characters and create a valid JSON array. An example of a valid input is:
```
1.8,1.9,latest
```

Additionally, the `preprocess-input` job removes space characters, this means that input like this is also handled properly:
```
1.8, 1.9, latest
```

