### PR TITLE
Point canonical/charming-actions/upload-bundle action to `main` branch instead of `1.0.0`

### DIFF
--- a/.github/workflows/run-tests-and-publish-bundle.yaml
+++ b/.github/workflows/run-tests-and-publish-bundle.yaml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Publish bundle release ${{ inputs.release }}
-        uses: mvlassis/charming-actions/upload-bundle@1.0.0
+        uses: mvlassis/charming-actions/upload-bundle
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-tests-and-publish-bundle.yaml
+++ b/.github/workflows/run-tests-and-publish-bundle.yaml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Publish bundle release ${{ inputs.release }}
-        uses: mvlassis/charming-actions/upload-bundle@main
+        uses: canonical/charming-actions/upload-bundle@main
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-tests-and-publish-bundle.yaml
+++ b/.github/workflows/run-tests-and-publish-bundle.yaml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Publish bundle release ${{ inputs.release }}
-        uses: mvlassis/charming-actions/upload-bundle
+        uses: mvlassis/charming-actions/upload-bundle@main
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-tests-and-publish-bundle.yaml
+++ b/.github/workflows/run-tests-and-publish-bundle.yaml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Publish bundle release ${{ inputs.release }}
-        uses: canonical/charming-actions/upload-bundle@1.0.0
+        uses: mvlassis/charming-actions/upload-bundle@1.0.0
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/get_bundle_path.py
+++ b/scripts/get_bundle_path.py
@@ -11,9 +11,9 @@ def get_bundle_path_from_release() -> None:
     release = sys.argv[1]
     bundle_is_latest = re.search("^latest/", release)
     if bundle_is_latest:
-        bundle_path = "./releases/" + release + "/"
+        bundle_path = "./releases/" + release + "/bundle.yaml"
     else:
-        bundle_path = "./releases/" + release + "/kubeflow/"
+        bundle_path = "./releases/" + release + "/kubeflow/bundle.yaml"
 
     # Check if file in bundle_path output exists
     # Expect the script to be executed from `bundle-kubeflow` repo directory

--- a/scripts/get_bundle_path.py
+++ b/scripts/get_bundle_path.py
@@ -11,9 +11,9 @@ def get_bundle_path_from_release() -> None:
     release = sys.argv[1]
     bundle_is_latest = re.search("^latest/", release)
     if bundle_is_latest:
-        bundle_path = "./releases/" + release + "/bundle.yaml"
+        bundle_path = "./releases/" + release + "/"
     else:
-        bundle_path = "./releases/" + release + "/kubeflow/bundle.yaml"
+        bundle_path = "./releases/" + release + "/kubeflow/"
 
     # Check if file in bundle_path output exists
     # Expect the script to be executed from `bundle-kubeflow` repo directory


### PR DESCRIPTION
Closes #828 along with [this PR](https://github.com/canonical/charming-actions/pull/151) in the [charming-actions](https://github.com/canonical/charming-actions) repo.

This PR updates the branch used in the `run-test-and-publish-bundle.yaml` to point to `main` instead of the old `1.0.0` branch.