### PR TITLE
Add Charmhub home page link to charmcraft.yaml

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,1 +1,3 @@
 type: bundle
+links:
+  documentation: https://discourse.charmhub.io/t/charmed-kubeflow-home-page/14447


### PR DESCRIPTION
## Issue
The [Kubeflow bundle page on Charmhub](https://charmhub.io/kubeflow) does not have a designated discourse index topic. 

## Solution
Add a link to a [home page topic](https://discourse.charmhub.io/t/charmed-kubeflow-home-page/14447) created  on discourse.charmhub.io. According to the [Juju/charmcraft documentation](https://juju.is/docs/sdk/charmcraft-yaml#heading--links), this must be done in the repository's `charmcraft.yaml` with the `link` key.

The discourse topic being linked has the following content:
```
# Charmed Kubeflow bundle

Charmed Kubeflow (CKF) is an open-source, end-to-end, production-ready [MLOps](https://ubuntu.com/blog/what-is-mlops) platform on top of cloud-native technologies. It is intended for data scientists and ML engineers, providing an advanced toolkit to organise and scale their work.

For information about how to deploy, integrate, and manage this charm bundle, see the [official Charmed Kubeflow documentation](https://charmed-kubeflow.io/docs).
```

This content will be rendered in the landing page [charmhub.io/kubeflow](https://charmhub.io/kubeflow).

---

Jira ticket: [DOCPR-707](https://warthogs.atlassian.net/jira/software/c/projects/DOCPR/boards/1180?assignee=712020%3A4834d254-070a-4247-9c7f-c6f46dbfc648&selectedIssue=DOCPR-707)

[DOCPR-707]: https://warthogs.atlassian.net/browse/DOCPR-707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ