### PR TITLE
Update parse_versions.py to properly receive input

### DIFF
--- a/scripts/gh-actions/parse_versions.py
+++ b/scripts/gh-actions/parse_versions.py
@@ -16,10 +16,13 @@ def parse_versions(input_versions):
     return json_array
 
 if __name__ == "__main__":
-    # Read the input of the Github Action from the environment variable
-    input_versions = os.getenv('INPUT_BUNDLE_VERSION', '')
+    if len(sys.argv) >= 1:
+        input_versions = parse_versions(sys.argv[1])
+    else:
+        input_versions = parse_versions(None)
     json_array = parse_versions(input_versions)
     print(f"bundle_versions={json_array}")
+
     with open(os.environ['GITHUB_OUTPUT'], 'a') as output_file:
         output_file.write(f"bundle_versions={json_array}\n")
 


### PR DESCRIPTION
Closes #1080.

This PR updates the `parse_versions.py` script to properly receive input from the arguments. It writes the output to the GITHUB_OUTPUT file. 