### PR TITLE
Add script to gather SBOMs for bundle images

### DIFF
--- a/.github/workflows/scan-images.yaml
+++ b/.github/workflows/scan-images.yaml
@@ -45,7 +45,7 @@ jobs:
           RISK=${BUNDLE_SPLIT[2]}
 
           pip3 install -r scripts/requirements.txt
-          python3 scripts/get-all-images.py ${{ matrix.bundle }}/bundle.yaml > image_list.txt
+          python3 scripts/get_all_images.py ${{ matrix.bundle }}/bundle.yaml > image_list.txt
           echo "Image list:"
           cat ./image_list.txt
           echo "release_risk=${RELEASE}-${RISK}" >> $GITHUB_OUTPUT

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,7 +8,7 @@ You can get a list of all the OCI images used by the bundle by running the follo
 ```bash
 pip3 install -r scripts/requirements.txt
 
-python3 scripts/get-all-images.py \
+python3 scripts/get_all_images.py \
     --append-images tests/airgapped/1.9/testing-images.txt \
     releases/1.9/stable/bundle.yaml \
     > images-all.txt
@@ -17,7 +17,7 @@ For Charmed Kubeflow 1.8, run
 ```bash
 pip3 install -r scripts/requirements.txt
 
-python3 scripts/get-all-images.py \
+python3 scripts/get_all_images.py \
     --append-images tests/airgapped/1.8/testing-images.txt \
     releases/1.9/stable/kubeflow/bundle.yaml \
     > images-all.txt

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -33,3 +33,30 @@ The script will gather the images in the following way:
 7. If the `get-images.sh` script either fails (return code non zero) or has error logs then the script should **fail**
 8. Aggregate the outputs of all `get-images.sh` scripts to one output
 9. If user passed an argument `--append-images` then the script will amend a list of images we need for airgap testing
+
+
+## Produce SBOM for images in a bundle
+
+### Prerequisites
+1. Install `syft` snap
+```
+sudo snap install syft --classic
+```
+
+2. Install `docker` snap
+```
+sudo snap install docker
+```
+Setup `docker` snap to run as a normal user by following the snap [documentation](https://snapcraft.io/docker).
+
+## Run SBOM producing script
+You can get a list of all the SBOMs for the images used by the bundle by running the following command:
+```
+python3 scripts/get_bundle_images_sbom.py <bundle_path>
+```
+For example for the 1.9 bundle, run:
+```
+python3 scripts/get_bundle_images_sbom.py releases/1.9/stable/bundle.yaml
+```
+
+This creates a directory under the repo's root with the name `images_SBOM`. The script will store all the SBOMs there. For each image, there will be the SBOM file formatted as `<image_name>.spdx.json`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -49,7 +49,16 @@ sudo snap install docker
 ```
 Setup `docker` snap to run as a normal user by following the snap [documentation](https://snapcraft.io/docker).
 
-## Run SBOM producing script
+3. Create a venv and install python requirements.
+Note that python version 3.10 is required to run the script.
+```
+python3 -m venv venv
+source venv/bin/activate
+
+pip3 install -r scripts/requirements.txt
+```
+
+### Run SBOM producing script
 You can get a list of all the SBOMs for the images used by the bundle by running the following command:
 ```
 python3 scripts/get_bundle_images_sbom.py <bundle_path>
@@ -59,4 +68,7 @@ For example for the 1.9 bundle, run:
 python3 scripts/get_bundle_images_sbom.py releases/1.9/stable/bundle.yaml
 ```
 
-This creates a directory under the repo's root with the name `images_SBOM`. The script will store all the SBOMs there. For each image, there will be the SBOM file formatted as `<image_name>.spdx.json`.
+> [!WARNING] 
+> To produce the SBOMs of all images in the bundle (~100 images), the script can take up to a few hours depending on the network and processing resources.
+
+The script creates a compressed file under the repo's root with the name `images_SBOM.tar.gz`. The script will store all the SBOMs there. For each image, there will be the SBOM file formatted as `<image_name>.spdx.json` inside the compressed file.

--- a/scripts/airgapped/README.md
+++ b/scripts/airgapped/README.md
@@ -34,7 +34,7 @@ This script makes the following assumptions:
 
 For Charmed Kubeflow 1.9, run:
 ```bash
-python3 scripts/get-all-images.py \
+python3 scripts/get_all_images.py \
     --append-images=tests/airgapped/1.9/testing-images.txt \
     releases/1.9/stable/bundle.yaml \
     > images.txt
@@ -42,7 +42,7 @@ python3 scripts/get-all-images.py \
 
 For Charmed Kubeflow 1.8, run:
 ```bash
-python3 scripts/get-all-images.py \
+python3 scripts/get_all_images.py \
     --append-images=tests/airgapped/1.8/testing-images.txt \
     releases/1.8/stable/kubeflow/bundle.yaml \
     > images.txt

--- a/scripts/get_all_images.py
+++ b/scripts/get_all_images.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import logging
 import subprocess

--- a/scripts/get_all_images.py
+++ b/scripts/get_all_images.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import argparse
 import logging
 import subprocess

--- a/scripts/get_bundle_images_sbom.py
+++ b/scripts/get_bundle_images_sbom.py
@@ -1,0 +1,43 @@
+import argparse
+import logging
+from pathlib import Path
+import subprocess
+
+from get_all_images import get_bundle_images
+
+SBOM_DIR = "images_SBOM"
+
+log = logging.getLogger(__name__)
+
+
+def get_bundle_images_sbom(bundle_path: str) -> None:
+
+    bundle_images = get_bundle_images(bundle_path)
+
+    Path(SBOM_DIR).mkdir(parents=True, exist_ok=True)
+
+    log.info(f"Images gathered from the bundle: {bundle_images}")
+
+    for image in bundle_images:
+        log.info(f"Creating SBOM for {image}")
+        try:
+            subprocess.check_call(
+                ['syft', 'scan', image, '-o', f'spdx-json={image}.spdx.json'],
+                cwd=SBOM_DIR,
+            )
+        except subprocess.CalledProcessError as e:
+            log.error(f"Error scanning {image}: {e.output}")
+            break
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get SBOMs for all images in a bundle.")
+    parser.add_argument("bundle", help="the bundle.yaml file to be scanned.")
+
+    args = parser.parse_args()
+
+    get_bundle_images_sbom(args.bundle)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/airgapped/1.8/katib/README.md
+++ b/tests/airgapped/1.8/katib/README.md
@@ -6,7 +6,7 @@ This directory is dedicated to testing Katib in an airgapped environment.
 
 Prepare the airgapped environment and deploy CKF by following the steps in [Airgapped test scripts](https://github.com/canonical/bundle-kubeflow/tree/main/tests/airgapped#testing-airgapped-installation).
 
-Once you run the test scripts, the `kubeflowkatib/simple-pbt:v0.16.0` image used in the `simple-pbt` experiment will be included in your airgapped environment. It's specifically added in the [`get-all-images.py` script](../../../../scripts/get-all-images.py).
+Once you run the test scripts, the `kubeflowkatib/simple-pbt:v0.16.0` image used in the `simple-pbt` experiment will be included in your airgapped environment. It's specifically added in the [`get_all_images.py` script](../../../../scripts/get_all_images.py).
 
 ## How to test Katib in an Airgapped environment
 1. Connect to the dashboard by visiting the IP of your airgapped VM. To get the IP run:

--- a/tests/airgapped/1.8/knative/README.md
+++ b/tests/airgapped/1.8/knative/README.md
@@ -6,7 +6,7 @@ This directory is dedicated to testing Knative in an airgapped environment.
 
 Prepare the airgapped environment and deploy CKF by following the steps in [Airgapped test scripts](https://github.com/canonical/bundle-kubeflow/tree/main/tests/airgapped#testing-airgapped-installation).
 
-Once you run the test scripts, the `knative/helloworld-go` image used in the `helloworld` example will be included in your airgapped environment. It's specifically added in the [`get-all-images.py` script](../../../../scripts/get-all-images.py).
+Once you run the test scripts, the `knative/helloworld-go` image used in the `helloworld` example will be included in your airgapped environment. It's specifically added in the [`get_all_images.py` script](../../../../scripts/get_all_images.py).
 
 ## How to test Knative in an Airgapped environment
 1. Connect to the dashboard by visiting the IP of your airgapped VM. To get the IP run:

--- a/tests/airgapped/1.8/pipelines/README.md
+++ b/tests/airgapped/1.8/pipelines/README.md
@@ -3,7 +3,7 @@
 ## The `kfp-airgapped-ipynb` Notebook
 To test Pipelines in Airgapped, we are using the Notebook in this directory. It contains the Data passing pipeline example, with the configuration of the Pipeline components to use the `pipelines-runner` [image](./pipelines-runner/README.md).
 
-The `pipelines-runner` image will be included in your airgapped environment given that you used the [Airgapped test scripts](../../README.md). It's specifically added in the [`get-all-images.py` script](../../../../scripts/airgapped/get-all-images.py).
+The `pipelines-runner` image will be included in your airgapped environment given that you used the [Airgapped test scripts](../../README.md). It's specifically added in the [`get_all_images.py` script](../../../../scripts/airgapped/get_all_images.py).
 
 ## How to test Pipelines in an Airgapped environment
 1. Prepare the airgapped environment and Deploy CKF by following the steps in [Airgapped test scripts](../../README.md).

--- a/tests/airgapped/1.8/training/README.md
+++ b/tests/airgapped/1.8/training/README.md
@@ -6,7 +6,7 @@ This directory is dedicated to testing training operator in an airgapped environ
 
 Prepare the airgapped environment and deploy CKF by following the steps in [Airgapped test scripts](../../README.md#testing-airgapped-installation).
 
-Once you run the test scripts, the `kubeflow-ci/tf-mnist-with-summaries:1.0` image used in the `tfjob-simple` training job will be included in your airgapped environment. It's specifically added in the [`get-all-images.py` script](../../../../scripts/get-all-images.py).
+Once you run the test scripts, the `kubeflow-ci/tf-mnist-with-summaries:1.0` image used in the `tfjob-simple` training job will be included in your airgapped environment. It's specifically added in the [`get_all_images.py` script](../../../../scripts/get_all_images.py).
 
 ## How to test training operator in an Airgapped environment
 1. Connect to the dashboard by visiting the IP of your airgapped VM. To get the IP run:

--- a/tests/airgapped/1.9/katib/README.md
+++ b/tests/airgapped/1.9/katib/README.md
@@ -6,7 +6,7 @@ This directory is dedicated to testing Katib in an airgapped environment.
 
 Prepare the airgapped environment and deploy CKF by following the steps in [Airgapped test scripts](https://github.com/canonical/bundle-kubeflow/tree/main/tests/airgapped#testing-airgapped-installation).
 
-Once you run the test scripts, the `kubeflowkatib/simple-pbt:v0.17.0` image used in the `simple-pbt` experiment will be included in your airgapped environment. It's specifically added in the [`get-all-images.py` script](../../../../scripts/airgapped/get-all-images.py).
+Once you run the test scripts, the `kubeflowkatib/simple-pbt:v0.17.0` image used in the `simple-pbt` experiment will be included in your airgapped environment. It's specifically added in the [`get_all_images.py` script](../../../../scripts/airgapped/get_all_images.py).
 
 ## How to test Katib in an Airgapped environment
 1. Connect to the dashboard by visiting the IP of your airgapped VM. To get the IP run:

--- a/tests/airgapped/1.9/knative/README.md
+++ b/tests/airgapped/1.9/knative/README.md
@@ -6,7 +6,7 @@ This directory is dedicated to testing Knative in an airgapped environment.
 
 Prepare the airgapped environment and deploy CKF by following the steps in [Airgapped test scripts](https://github.com/canonical/bundle-kubeflow/tree/main/tests/airgapped#testing-airgapped-installation).
 
-Once you run the test scripts, the `knative/helloworld-go` image used in the `helloworld` example will be included in your airgapped environment. It's specifically added in the [`get-all-images.py` script](../../../../scripts/get-all-images.py).
+Once you run the test scripts, the `knative/helloworld-go` image used in the `helloworld` example will be included in your airgapped environment. It's specifically added in the [`get_all_images.py` script](../../../../scripts/get_all_images.py).
 
 ## How to test Knative in an Airgapped environment
 1. Connect to the dashboard by visiting the IP of your airgapped VM. To get the IP run:

--- a/tests/airgapped/1.9/pipelines/README.md
+++ b/tests/airgapped/1.9/pipelines/README.md
@@ -3,7 +3,7 @@
 ## The `kfp-airgapped-ipynb` Notebook
 To test Pipelines in Airgapped, we are using the Notebook in this directory. It contains the Data passing pipeline example, with the configuration of the Pipeline components to use the `pipelines-runner` [image](./pipelines-runner/README.md).
 
-The `pipelines-runner` image will be included in your airgapped environment given that you used the [Airgapped test scripts](../README.md). It's specifically added in the [`get-all-images.py` script](../../../../scripts/get-all-images.py).
+The `pipelines-runner` image will be included in your airgapped environment given that you used the [Airgapped test scripts](../README.md). It's specifically added in the [`get_all_images.py` script](../../../../scripts/get_all_images.py).
 
 ## How to test Pipelines in an Airgapped environment
 1. Prepare the airgapped environment and Deploy CKF by following the steps in [Airgapped test scripts](../../README.md).

--- a/tests/airgapped/1.9/training/README.md
+++ b/tests/airgapped/1.9/training/README.md
@@ -6,7 +6,7 @@ This directory is dedicated to testing training operator in an airgapped environ
 
 Prepare the airgapped environment and deploy CKF by following the steps in [Airgapped test scripts](../../README.md#testing-airgapped-installation).
 
-Once you run the test scripts, the `kubeflow/tf-mnist-with-summaries:latest` image used in the `tfjob-simple` training job will be included in your airgapped environment. It's specifically added in the [`get-all-images.py` script](../../../../scripts/get-all-images.py).
+Once you run the test scripts, the `kubeflow/tf-mnist-with-summaries:latest` image used in the `tfjob-simple` training job will be included in your airgapped environment. It's specifically added in the [`get_all_images.py` script](../../../../scripts/get_all_images.py).
 
 ## How to test training operator in an Airgapped environment
 1. Connect to the dashboard by visiting the IP of your airgapped VM. To get the IP run:

--- a/tests/airgapped/README.md
+++ b/tests/airgapped/README.md
@@ -75,7 +75,7 @@ Developers are urged to instead define their own `images.txt` file with the imag
 they'd like to be loaded during tests.
 
 ```bash
-python3 scripts/airgapped/get-all-images.py \
+python3 scripts/airgapped/get_all_images.py \
     releases/1.9/stable/bundle.yaml \
     > images-all.txt
 ```

--- a/tests/airgapped/ckf.sh
+++ b/tests/airgapped/ckf.sh
@@ -17,7 +17,7 @@ function create_images_tar() {
   pip3 install -r scripts/airgapped/requirements.txt
 
   echo "Generating list of images of Charmed Kubeflow"
-  python3 scripts/get-all-images.py \
+  python3 scripts/get_all_images.py \
     --append-images "$TESTING_IMAGES_PATH" \
     "$BUNDLE_PATH" \
     > images.txt


### PR DESCRIPTION
closes #1078 

## Summary
* creates a python script that produces a `.tar.gz` containing the SBOMs for images in the bundle
  * the script uses `syft` to produce the SBOMs
  * the script uses the `syft` command advised by the security team
  * the script relies on the existing `get-all-images.py` script to get the images used in kubeflow bundle
* renames the `get-all-images.py` module to `get_all_images.py` to be able to be imported from the new script

The .tar.gz produced can be found in [the team's Gdrive](https://drive.google.com/drive/folders/1vO8ipGMDryezuuNOaN995-OSKZepSf65?usp=drive_link)

**Note** this script does not apply to mlflow images, see https://github.com/canonical/bundle-kubeflow/issues/1078#issuecomment-2393150377 for how to generate the mlflow images SBOMs.

## Testing
To get the SBOMs for kubeflow `1.9/stable` bundle images:
1. Clone the `bundle-kubeflow` repo
2. Checkout to the branch `KF-6280-script-images-sbom`
3. Follow the prerequisites added in the readme (install syft and docker snaps)
4. Run the script with:
```
python3 scripts/get_bundle_images_sbom.py releases/1.9/stable/bundle.yaml
```