### PR TITLE
ci: add missing charms to the Scan images workflow

### DIFF
--- a/.github/workflows/get-images-and-scan.yaml
+++ b/.github/workflows/get-images-and-scan.yaml
@@ -24,7 +24,17 @@ jobs:
     - name: Run get-all-images.py
       run: |
         pip3 install -r scripts/requirements.txt
-        python3 scripts/get_all_images.py releases/${{ inputs.bundle-directory }}/bundle.yaml > /tmp/images_list.txt
+        # The get_all_images.py does not provide a way to include extra repositories to fetch images from.
+        # In order to include the resource-dispatcher and the namespace-node-affinity charms in the scans,
+        # they can be passed using the --append-images argument.
+        if [[ ${{ inputs.bundle-directory }}  == *"1.8"* ]]; then
+          echo 'charmedkubeflow/resource-dispatcher:1.0-22.04' >> /tmp/extra-images.txt
+          echo 'charmedkubeflow/namespace-node-affinity:90dde45ab265af91369d09a377a26034bc453a5d' >> /tmp/extra-images.txt
+        else
+          echo 'charmedkubeflow/resource-dispatcher:2.0-22.04' >> /tmp/extra-images.txt
+          echo 'charmedkubeflow/namespace-node-affinity:2.2.0' >> /tmp/extra-images.txt
+        fi
+        python3 scripts/get_all_images.py releases/${{ inputs.bundle-directory }}/bundle.yaml --append-images /tmp/extra-images.txt > /tmp/images_list.txt
 
     - name: Generate an array of images
       id: set-images-array


### PR DESCRIPTION
Adding resource-dispatcher and namespace-node-affinity to the list of images to be scanned. While they do not necessarily belong to the bundle, they have to be scanned as part of the team's vulnerability response.

Fixes #1084

#### For reviewers

[Here's](https://github.com/canonical/bundle-kubeflow/actions/runs/11338619320/job/31532130158) a run for the proposed changes.

* [L530 and L531](https://github.com/canonical/bundle-kubeflow/actions/runs/11338619320/job/31532130158#step:3:531) show the images that were added for the 1.8 scan
* [L508 and L509](https://github.com/canonical/bundle-kubeflow/actions/runs/11338619320/job/31532130001#step:3:509) show the images that were added for the 1.9 scan
* [L508 and L509](https://github.com/canonical/bundle-kubeflow/actions/runs/11338619320/job/31532130369#step:3:509) show the images that were added for the latest/edge scan

At the same time, we can see the images are now scanned, for example [here](https://github.com/canonical/bundle-kubeflow/actions/runs/11338619320/job/31532207014)