### PR TITLE
Update AKS and EKS action to properly run on schedule

### DIFF
--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -36,6 +36,9 @@ jobs:
         id: process_bundle_versions
         run: |
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
+              # There is an issue when writing multiline strings gto $GITHUB_OUTPUT
+              # So we remove them with tr as a workaround
+              # See: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings
               bundle_versions=$(yq '. | keys' .github/dependencies.yaml -o=json | tr -d '\n')
               echo "bundle_versions=${bundle_versions}"
               echo "bundle_versions=${bundle_versions}" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        bundle_version: ${{ fromJSON(needs.preprocess-input.outputs.processed_bundle_versions) || fromJSON(jobs.generate-bundle-versions-on-schedule.outputs.bundle_versions) }}
+        bundle_version: ${{ fromJSON(needs.preprocess-input.outputs.processed_bundle_versions) || fromJSON(needs.generate-bundle-versions-on-schedule.outputs.bundle_versions) }}
       fail-fast: false
     env:
       AZURE_CORE_OUTPUT: none

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -36,11 +36,12 @@ jobs:
         id: process_bundle_versions
         run: |
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
-              bundle_versions=$(yq '. | keys' .github/dependencies.yaml -o=json)
+              bundle_versions=$(yq '. | keys' .github/dependencies.yaml -o=json | tr -d '\n')
+              echo "bundle_versions=${bundle_versions}"
               echo "bundle_versions=${bundle_versions}" >> $GITHUB_OUTPUT
           else
               python scripts/gh-actions/parse_versions.py "${{ inputs.bundle_version }}"
-          fi          
+          fi
       
   deploy-ckf-to-aks:
     needs: preprocess-input

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -21,7 +21,7 @@ jobs:
       processed_bundle_versions: ${{ steps.process_bundle_versions.outputs.bundle_versions }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run YAML to Github Output Action
         id: yaml-output

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        bundle_version: ${{ fromJSON(needs.preprocess-input.outputs.processed_bundle_versions) fromJSON(needs.generate-bundle-versions-on-schedule.outputs.bundle_versions) }}
+        bundle_version: ${{ fromJSON(needs.preprocess-input.outputs.processed_bundle_versions) || fromJSON(needs.generate-bundle-versions-on-schedule.outputs.bundle_versions) }}
       fail-fast: false
     env:
       AZURE_CORE_OUTPUT: none

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -28,33 +28,27 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-          
-      - name: Process bundle versions
-        id: process_bundle_versions
-        run: python scripts/gh-actions/parse_versions.py "${{ inputs.bundle_version }}"
-
-  generate-bundle-versions-on-schedule:
-    if: ${{ github.event_name == 'schedule' }}
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
 
       - name: Install CLI tools
         run: |
           sudo snap install yq
-        
-      - name: Create JSON array of bundle versions
+          
+      - name: Process bundle versions
+        id: process_bundle_versions
         run: |
-          bundle_versions=$(yq '. | keys' .github/dependencies.yaml -o=json)
-          echo "bundle_versions=${bundle_versions}" >> $GITHUB_OUTPUT
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+              bundle_versions=$(yq '. | keys' .github/dependencies.yaml -o=json)
+              echo "bundle_versions=${bundle_versions}" >> $GITHUB_OUTPUT
+          else
+              python scripts/gh-actions/parse_versions.py "${{ inputs.bundle_version }}"
+          fi          
       
   deploy-ckf-to-aks:
     needs: preprocess-input
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        bundle_version: ${{ fromJSON(needs.preprocess-input.outputs.processed_bundle_versions) || fromJSON(needs.generate-bundle-versions-on-schedule.outputs.bundle_versions) }}
+        bundle_version: ${{ fromJSON(needs.preprocess-input.outputs.processed_bundle_versions) }}
       fail-fast: false
     env:
       AZURE_CORE_OUTPUT: none

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -36,9 +36,8 @@ jobs:
         id: process_bundle_versions
         run: |
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
-              # There is an issue when writing multiline strings gto $GITHUB_OUTPUT
-              # So we remove them with tr as a workaround
-              # See: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings
+              # Use `tr` to remove new lines as a workaround to:
+              # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strngs
               bundle_versions=$(yq '. | keys' .github/dependencies.yaml -o=json | tr -d '\n')
               echo "bundle_versions=${bundle_versions}"
               echo "bundle_versions=${bundle_versions}" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -16,13 +16,12 @@ on:
     - cron: "17 0 * * 2"
 jobs:
   preprocess-input:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-22.04
     outputs:
       processed_bundle_versions: ${{ steps.process_bundle_versions.outputs.bundle_versions }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        bundle_version: ${{ fromJSON(needs.generate-bundle-versions-on-schedule.outputs.bundle_versions) || fromJSON(needs.preprocess-input.outputs.processed_bundle_versions) }}
+        bundle_version: ${{ fromJSON(needs.preprocess-input.outputs.processed_bundle_versions) fromJSON(needs.generate-bundle-versions-on-schedule.outputs.bundle_versions) }}
       fail-fast: false
     env:
       AZURE_CORE_OUTPUT: none

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        bundle_version: ${{ fromJSON(needs.preprocess-input.outputs.processed_bundle_versions) || fromJSON(needs.generate-bundle-versions-on-schedule.outputs.bundle_versions) }}
+        bundle_version: ${{ fromJSON(needs.generate-bundle-versions-on-schedule.outputs.bundle_versions) || fromJSON(needs.preprocess-input.outputs.processed_bundle_versions) }}
       fail-fast: false
     env:
       AZURE_CORE_OUTPUT: none

--- a/.github/workflows/deploy-to-eks.yaml
+++ b/.github/workflows/deploy-to-eks.yaml
@@ -36,6 +36,9 @@ jobs:
         id: process_bundle_versions
         run: |
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
+              # There is an issue when writing multiline strings gto $GITHUB_OUTPUT
+              # So we remove them with tr as a workaround
+              # See: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings
               bundle_versions=$(yq '. | keys' .github/dependencies.yaml -o=json | tr -d '\n')
               echo "bundle_versions=${bundle_versions}"
               echo "bundle_versions=${bundle_versions}" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-to-eks.yaml
+++ b/.github/workflows/deploy-to-eks.yaml
@@ -21,7 +21,7 @@ jobs:
       processed_bundle_versions: ${{ steps.process_bundle_versions.outputs.bundle_versions }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/deploy-to-eks.yaml
+++ b/.github/workflows/deploy-to-eks.yaml
@@ -16,45 +16,39 @@ on:
     - cron: "23 0 * * 2"
 jobs:
   preprocess-input:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-22.04
     outputs:
       processed_bundle_versions: ${{ steps.process_bundle_versions.outputs.bundle_versions }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-          
-      - name: Process bundle versions
-        id: process_bundle_versions
-        run: python scripts/gh-actions/parse_versions.py "${{ inputs.bundle_version }}"
-        
-  generate-bundle-versions-on-schedule:
-    if: ${{ github.event_name == 'schedule' }}
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
 
       - name: Install CLI tools
         run: |
           sudo snap install yq
-        
-      - name: Create JSON array of bundle versions
+          
+      - name: Process bundle versions
+        id: process_bundle_versions
         run: |
-          bundle_versions=$(yq '. | keys' .github/dependencies.yaml -o=json)
-          echo "bundle_versions=${bundle_versions}" >> $GITHUB_OUTPUT
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+              bundle_versions=$(yq '. | keys' .github/dependencies.yaml -o=json | tr -d '\n')
+              echo "bundle_versions=${bundle_versions}"
+              echo "bundle_versions=${bundle_versions}" >> $GITHUB_OUTPUT
+          else
+              python scripts/gh-actions/parse_versions.py "${{ inputs.bundle_version }}"
+          fi
         
   deploy-ckf-to-eks:
     needs: preprocess-input
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        bundle_version: ${{ fromJSON(needs.preprocess-input.outputs.processed_bundle_versions) || fromJSON(jobs.generate-bundle-versions-on-schedule.outputs.bundle_versions) }}
+        bundle_version: ${{ fromJSON(needs.preprocess-input.outputs.processed_bundle_versions) }}
       fail-fast: false
     env:
       PYTHON_VERSION: "3.8"

--- a/.github/workflows/deploy-to-eks.yaml
+++ b/.github/workflows/deploy-to-eks.yaml
@@ -36,9 +36,8 @@ jobs:
         id: process_bundle_versions
         run: |
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
-              # There is an issue when writing multiline strings gto $GITHUB_OUTPUT
-              # So we remove them with tr as a workaround
-              # See: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings
+              # Use `tr` to remove new lines as a workaround to:
+              # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strngs
               bundle_versions=$(yq '. | keys' .github/dependencies.yaml -o=json | tr -d '\n')
               echo "bundle_versions=${bundle_versions}"
               echo "bundle_versions=${bundle_versions}" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-to-eks.yaml
+++ b/.github/workflows/deploy-to-eks.yaml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run YAML to Github Output Action
         id: yaml-output


### PR DESCRIPTION
Closes #1124.

This PR updates the `deploy-to-aks.yaml` and `deploy-to-eks.yaml` files to properly run on schedule.

The current issue that we had to overcome is explained [here](https://github.com/canonical/bundle-kubeflow/issues/1124#issuecomment-2476481572)

To fix this issue, I have condensed the 2 jobs into 1 job that always run, and the `if` statements are located inside run

Note that there is an issue when writing multiline strings to $GITHUB_OUTPUT, and that's why we run `tr` to remove all newline characters from the JSON output of `yq`.