### PR TITLE
[KF-5958] Upgrade to Python3.10+

### DIFF
--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -16,7 +16,7 @@ on:
     - cron: "17 0 * * 2"
 jobs:
   preprocess-input:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       processed_bundle_versions: ${{ steps.process_bundle_versions.outputs.bundle_versions }}
     steps:
@@ -42,7 +42,7 @@ jobs:
       
   deploy-ckf-to-aks:
     needs: preprocess-input
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         bundle_version: ${{ fromJSON(needs.preprocess-input.outputs.processed_bundle_versions) }}

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -23,11 +23,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-
       - name: Install CLI tools
         run: |
           sudo snap install yq
@@ -54,7 +49,6 @@ jobs:
       fail-fast: false
     env:
       AZURE_CORE_OUTPUT: none
-      PYTHON_VERSION: "3.8"
 
     steps:
       - name: Checkout repository
@@ -74,19 +68,9 @@ jobs:
           UATS_BRANCH=${{ inputs.uats_branch || env.UATS_BRANCH }}
           echo "UATS_BRANCH=${UATS_BRANCH}" >> $GITHUB_ENV
 
-      # Remove once https://github.com/canonical/bundle-kubeflow/issues/761
-      # is resolved and applied to uats repository.
-      - name: Install python ${{ env.PYTHON_VERSION }}
-        run: |
-          sudo add-apt-repository ppa:deadsnakes/ppa -y
-          sudo apt update -y
-          sudo apt install python${{ env.PYTHON_VERSION }} python${{ env.PYTHON_VERSION }}-distutils python${{ env.PYTHON_VERSION }}-venv -y
-
       - name: Install CLI tools
         run: |
-          wget https://bootstrap.pypa.io/get-pip.py
-          python${{ env.PYTHON_VERSION }} get-pip.py
-          python${{ env.PYTHON_VERSION }} -m pip install tox
+          pip install tox 
           sudo snap install juju --classic --channel=${{ env.JUJU_VERSION }}/stable
           sudo snap install charmcraft --classic
           juju version

--- a/.github/workflows/deploy-to-eks.yaml
+++ b/.github/workflows/deploy-to-eks.yaml
@@ -16,7 +16,7 @@ on:
     - cron: "23 0 * * 2"
 jobs:
   preprocess-input:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       processed_bundle_versions: ${{ steps.process_bundle_versions.outputs.bundle_versions }}
     steps:
@@ -42,7 +42,7 @@ jobs:
         
   deploy-ckf-to-eks:
     needs: preprocess-input
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         bundle_version: ${{ fromJSON(needs.preprocess-input.outputs.processed_bundle_versions) }}

--- a/.github/workflows/deploy-to-eks.yaml
+++ b/.github/workflows/deploy-to-eks.yaml
@@ -23,11 +23,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-
       - name: Install CLI tools
         run: |
           sudo snap install yq
@@ -52,8 +47,6 @@ jobs:
       matrix:
         bundle_version: ${{ fromJSON(needs.preprocess-input.outputs.processed_bundle_versions) }}
       fail-fast: false
-    env:
-      PYTHON_VERSION: "3.8"
 
     steps:
       - name: Checkout repository
@@ -73,19 +66,9 @@ jobs:
           UATS_BRANCH=${{ inputs.uats_branch || env.UATS_BRANCH }}
           echo "UATS_BRANCH=${UATS_BRANCH}" >> $GITHUB_ENV
 
-      # Remove once https://github.com/canonical/bundle-kubeflow/issues/761
-      # is resolved and applied to uats repository.
-      - name: Install python ${{ env.PYTHON_VERSION }}
-        run: |
-          sudo add-apt-repository ppa:deadsnakes/ppa -y
-          sudo apt update -y
-          sudo apt install python${{ env.PYTHON_VERSION }} python${{ env.PYTHON_VERSION }}-distutils python${{ env.PYTHON_VERSION }}-venv -y
-
       - name: Install CLI tools
         run: |
-          wget https://bootstrap.pypa.io/get-pip.py
-          python${{ env.PYTHON_VERSION }} get-pip.py
-          python${{ env.PYTHON_VERSION }} -m pip install tox
+          pip install tox
           sudo snap install juju --channel=${{ env.JUJU_VERSION }}/stable
           sudo snap install charmcraft --classic
           juju version

--- a/.github/workflows/full-bundle-tests.yaml
+++ b/.github/workflows/full-bundle-tests.yaml
@@ -77,34 +77,8 @@ jobs:
           }
           EOF
 
-      - name: Setup Python 3.8
-        run: |
-          echo "deb-src http://archive.ubuntu.com/ubuntu/ jammy main" | sudo tee -a /etc/apt/sources.list
-
-          sudo apt-get update -yqq
-          sudo apt-get build-dep -yqq python3
-          sudo apt-get install -yqq pkg-config
-
-          sudo apt-get install -yqq build-essential gdb lcov pkg-config \
-            libbz2-dev libffi-dev libgdbm-dev libgdbm-compat-dev liblzma-dev \
-            libncurses5-dev libreadline6-dev libsqlite3-dev libssl-dev \
-            lzma lzma-dev tk-dev uuid-dev zlib1g-dev
-
-          curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
-
-          export PYENV_ROOT="$HOME/.pyenv"
-          command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
-
-          pyenv install 3.8.16
-          pyenv global 3.8.16
-
-          # configure environment variables to be available in subsequent steps
-          echo "PYENV_ROOT=$PYENV_ROOT" >> "$GITHUB_ENV"
-          echo "PATH=$PATH" >> "$GITHUB_ENV"
-
       - name: Install tox
         run: |
-          eval "$(pyenv init -)"
           pip install tox
 
       - name: Setup operator environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ description = "charmed-kubeflow.io"
 authors = [""]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = ">=3.10"
 click = "^7"
 pyyaml = "^5.3"
 


### PR DESCRIPTION
Testing the upgrade of the Kubeflow UAT to Python 3.10 or 3.12, see https://github.com/canonical/charmed-kubeflow-uats/pull/137

The AKS and EKS runs have been positive using noble with python 3.12:

* [EKS](https://github.com/canonical/bundle-kubeflow/actions/runs/11978574125/job/33398942758)
* [AKS](https://github.com/canonical/bundle-kubeflow/actions/runs/11976053369/job/33390856205)

