### PR TITLE
fix: update `get_releases_affected.py` with 1.9

### DIFF
--- a/scripts/get_releases_affected.py
+++ b/scripts/get_releases_affected.py
@@ -4,7 +4,7 @@ import os
 import re
 import sys
 
-ACCEPTED_TRACKS = ["1.7", "1.8", "latest"]
+ACCEPTED_TRACKS = ["1.7", "1.8", "1.9", "latest"]
 ACCEPTED_RISKS = ["beta", "edge", "stable"]
 
 


### PR DESCRIPTION
Updates the get releases script to include 1.9 bundle definitions.
See how it failed in https://github.com/canonical/bundle-kubeflow/actions/runs/12135466742/job/33834580034.