### PR TITLE
fix(ci): Cleanup CloudFormation stack when EKS cluster creation fails

### DIFF
--- a/.github/workflows/deploy-to-eks.yaml
+++ b/.github/workflows/deploy-to-eks.yaml
@@ -179,6 +179,14 @@ jobs:
           VERSION_WITHOUT_DOT="${VERSION//.}"
           eksctl delete cluster --region eu-central-1 --name=kubeflow-test-$VERSION_WITHOUT_DOT
 
+        # Clean up leftover CloudFormation stack when cluster creation fails unexpectedly
+      - name: Delete CloudFormation stack (if present)
+        if: always()
+        run: |
+          VERSION=${{ matrix.bundle_version }}
+          VERSION_WITHOUT_DOT="${VERSION//.}"
+          aws cloudformation delete-stack --region eu-central-1 --stack-name eksctl-kubeflow-test-$VERSION_WITHOUT_DOT-cluster
+
   delete-unattached-volumes:
     if: always()
     uses: ./.github/workflows/delete-aws-volumes.yaml


### PR DESCRIPTION
Fix #1173

#### Testing
We can see that this work because the workflow was run from the PR's branch and 
1. The run failed exactly as in the linked issue in first attempt https://github.com/canonical/bundle-kubeflow/actions/runs/12137293822/job/33840248459#step:11:54 which means that it started creating a cloudformation but exited due to cluster creation failure
2. [Second attempt](https://github.com/canonical/bundle-kubeflow/actions/runs/12137293822/job/33840508643#step:11:42) started creating a CloudFormation stack instead of failing with: 
  ```
  2024-12-03 09:38:10 [✖]  creating CloudFormation stack "eksctl-kubeflow-test-latest-cluster": operation error CloudFormation: CreateStack, https response error StatusCode: 400, RequestID: 2a8e4[22](https://github.com/canonical/bundle-kubeflow/actions/runs/12130614512/job/33838826606#step:11:23)4-5f7b-4f7b-881b-a99e0e15d5b0, AlreadyExistsException: Stack [eksctl-kubeflow-test-latest-cluster] already exists
  ```