### PR TITLE
ci: bump juju to 3.6

### DIFF
--- a/.github/dependencies.yaml
+++ b/.github/dependencies.yaml
@@ -4,9 +4,9 @@
   UATS_BRANCH: "track/1.8"
 "1.9":
   K8S_VERSION: "1.29"
-  JUJU_VERSION: "3.4"
+  JUJU_VERSION: "3.6"
   UATS_BRANCH: "main"
 latest:
   K8S_VERSION: "1.29"
-  JUJU_VERSION: "3.4"
+  JUJU_VERSION: "3.6"
   UATS_BRANCH: "main"

--- a/.github/workflows/full-bundle-tests.yaml
+++ b/.github/workflows/full-bundle-tests.yaml
@@ -17,7 +17,7 @@ on:
       juju-channel:
         description: Juju channel e.g. 3.5/stable
         required: false
-        default: "3.4/stable"
+        default: "3.6/stable"
   workflow_call:
     inputs:
       bundle-source:


### PR DESCRIPTION
Note that this doesn't bump PATCH version because it is removed in #1181.

Ref #1156