### PR TITLE
chore(ci): bump EKS ubuntu image to 22.04

### DIFF
--- a/.github/cluster.yaml
+++ b/.github/cluster.yaml
@@ -14,7 +14,7 @@ kind: ClusterConfig
 kubernetesNetworkConfig:
   ipFamily: IPv4
 managedNodeGroups:
-- amiFamily: Ubuntu2004
+- amiFamily: Ubuntu2204
   iam:
     withAddonPolicies:
       ebs: true


### PR DESCRIPTION
Bump Ubuntu image used in EKS CI to 22.04 to:
 1. use latest LTS available in eksctl. See https://eksctl.io/usage/custom-ami-support/#setting-the-node-ami-family.
 2. resolve incompatibility between k8s version 1.31 and Ubuntu 20.04.

Fix #1200

#### Testing
See this example run https://github.com/canonical/bundle-kubeflow/actions/runs/13268173276/job/37040851598 from the PR's branch.