### PR TITLE
type: fix EKS Katib failing test

### DIFF
--- a/.github/cluster.yaml
+++ b/.github/cluster.yaml
@@ -27,7 +27,7 @@ managedNodeGroups:
   name: ng-d06bd84e
   releaseVersion: ""
   ssh:
-    allow: false
+    allow: true
   tags:
     alpha.eksctl.io/nodegroup-name: ng-d06bd84e
     alpha.eksctl.io/nodegroup-type: managed

--- a/.github/workflows/deploy-to-eks.yaml
+++ b/.github/workflows/deploy-to-eks.yaml
@@ -110,7 +110,8 @@ jobs:
           kubectl get nodes
 
       - name: Configure EKS Nodes
-        run: |          
+        run: |         
+          echo "Configuring sysctl on EKS workers"
           source ./scripts/gh-actions/set_eks_sysctl_config.sh
 
       - name: Setup juju

--- a/.github/workflows/deploy-to-eks.yaml
+++ b/.github/workflows/deploy-to-eks.yaml
@@ -102,9 +102,48 @@ jobs:
           VERSION_WITHOUT_DOT="${VERSION//.}"
           yq e ".metadata.name |= \"kubeflow-test-$VERSION_WITHOUT_DOT\"" -i .github/cluster.yaml
           yq e ".metadata.version |= \"${{ env.K8S_VERSION }}\"" -i .github/cluster.yaml
+
+          # Generate ssh-key pair
+          ssh-keygen -q -t rsa -N '' -f ~/.ssh/id_rsa <<<y >/dev/null 2>&1
+
           eksctl create cluster -f .github/cluster.yaml
           kubectl get nodes
-      
+
+      - name: Configure EKS Nodes
+        run: |
+          
+          # Export all instances
+          aws ec2 describe-instances \
+            --filters Name=instance-state-name,Values=running \
+            --output yaml > instances.yaml
+
+          INTERNAL_DNS=$(kubectl get nodes -A | tail -n+2 | awk '{print $1}')
+                    
+          for DNS in $INTERNAL_DNS;
+          do
+            # Figure out external dns
+            DNS_QUERY=".Reservations[].Instances | flatten | map(select(.PrivateDnsName==\"${DNS}\"))[].PublicDnsName"
+            echo $DNS_QUERY
+            EXTERNAL_DNS=$(yq "$DNS_QUERY" instances.yaml)
+
+            echo "=========================================="
+            echo "Internal DNS: ${DNS}"
+            echo "Using external DNS: ${EXTERNAL_DNS}"
+            SSH_CMD="ssh -o StrictHostKeyChecking=no ubuntu@$EXTERNAL_DNS"
+          
+            # Setting the sysctl properties
+            echo "Setting values"
+            $SSH_CMD 'sudo sysctl fs.inotify.max_user_watches=655360'
+            $SSH_CMD 'sudo sysctl fs.inotify.max_user_instances=1280'
+          
+            # To check the settings
+            echo "Checking values"
+            $SSH_CMD 'sudo sysctl -a | grep "^fs.inotify"'
+            echo "=========================================="
+          done
+          
+          rm instances.yaml
+
       - name: Setup juju
         run: |
           # Call juju bin directly as a workaround to https://bugs.launchpad.net/juju/+bug/2007575

--- a/.github/workflows/deploy-to-eks.yaml
+++ b/.github/workflows/deploy-to-eks.yaml
@@ -110,39 +110,8 @@ jobs:
           kubectl get nodes
 
       - name: Configure EKS Nodes
-        run: |
-          
-          # Export all instances
-          aws ec2 describe-instances \
-            --filters Name=instance-state-name,Values=running \
-            --output yaml > instances.yaml
-
-          INTERNAL_DNS=$(kubectl get nodes -A | tail -n+2 | awk '{print $1}')
-                    
-          for DNS in $INTERNAL_DNS;
-          do
-            # Figure out external dns
-            DNS_QUERY=".Reservations[].Instances | flatten | map(select(.PrivateDnsName==\"${DNS}\"))[].PublicDnsName"
-            echo $DNS_QUERY
-            EXTERNAL_DNS=$(yq "$DNS_QUERY" instances.yaml)
-
-            echo "=========================================="
-            echo "Internal DNS: ${DNS}"
-            echo "Using external DNS: ${EXTERNAL_DNS}"
-            SSH_CMD="ssh -o StrictHostKeyChecking=no ubuntu@$EXTERNAL_DNS"
-          
-            # Setting the sysctl properties
-            echo "Setting values"
-            $SSH_CMD 'sudo sysctl fs.inotify.max_user_watches=655360'
-            $SSH_CMD 'sudo sysctl fs.inotify.max_user_instances=1280'
-          
-            # To check the settings
-            echo "Checking values"
-            $SSH_CMD 'sudo sysctl -a | grep "^fs.inotify"'
-            echo "=========================================="
-          done
-          
-          rm instances.yaml
+        run: |          
+          source ./scripts/gh-actions/set_eks_sysctl_config.sh
 
       - name: Setup juju
         run: |

--- a/scripts/gh-actions/set_eks_sysctl_config.sh
+++ b/scripts/gh-actions/set_eks_sysctl_config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -xe
 # This script checks that the sysctl are correctly set on an EKS cluster
 
 function check_sysctl(){

--- a/scripts/gh-actions/set_eks_sysctl_config.sh
+++ b/scripts/gh-actions/set_eks_sysctl_config.sh
@@ -11,7 +11,10 @@ function check_sysctl(){
 
     if [ "$CURRENT" != "$VALUE" ]
     then
+      echo "Failing check for ${KEY}: current ${CURRENT} expected: ${VALUE}"
       exit 1
+    else
+      echo "Check for ${KEY} passed successfully"
     fi
 }
 
@@ -32,6 +35,7 @@ do
   echo "=========================================="
   echo "Internal DNS: ${DNS}"
   echo "Using external DNS: ${EXTERNAL_DNS}"
+
   SSH_CMD="ssh -o StrictHostKeyChecking=no ubuntu@$EXTERNAL_DNS"
 
   # Setting the sysctl properties
@@ -41,7 +45,7 @@ do
 
   # To check the settings
   echo "Checking values"
-  check_sysctl "$SSH_CMD" "fs.inotify.max_user_watches" "65536"
+  check_sysctl "$SSH_CMD" "fs.inotify.max_user_watches" "655360"
   check_sysctl "$SSH_CMD" "fs.inotify.max_user_instances" "1280"
   echo "=========================================="
 done

--- a/scripts/gh-actions/set_eks_sysctl_config.sh
+++ b/scripts/gh-actions/set_eks_sysctl_config.sh
@@ -41,8 +41,8 @@ do
 
   # To check the settings
   echo "Checking values"
-  check_sysctl $SSH_CMD "fs.inotify.max_user_watches" "65536"
-  check_sysctl $SSH_CMD "fs.inotify.max_user_instances" "1280"
+  check_sysctl "$SSH_CMD" "fs.inotify.max_user_watches" "65536"
+  check_sysctl "$SSH_CMD" "fs.inotify.max_user_instances" "1280"
   echo "=========================================="
 done
 

--- a/scripts/gh-actions/set_eks_sysctl_config.sh
+++ b/scripts/gh-actions/set_eks_sysctl_config.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# This script checks that the sysctl are correctly set on an EKS cluster
+
+function check_sysctl(){
+    SSH_CMD=$1
+    KEY=$2
+    VALUE=$3
+
+    CURRENT=$($SSH_CMD 'sudo sysctl -a 2>/dev/null' | grep "^${KEY}" | cut -d "=" -f 2 | xargs)
+
+    if [ "$CURRENT" != "$VALUE" ]
+    then
+      exit 1
+    fi
+}
+
+# Export all instances
+aws ec2 describe-instances \
+  --filters Name=instance-state-name,Values=running \
+  --output yaml > instances.yaml
+
+INTERNAL_DNS=$(kubectl get nodes -A | tail -n+2 | awk '{print $1}')
+
+for DNS in $INTERNAL_DNS;
+do
+  # Figure out external dns
+  DNS_QUERY=".Reservations[].Instances | flatten | map(select(.PrivateDnsName==\"${DNS}\"))[].PublicDnsName"
+  echo $DNS_QUERY
+  EXTERNAL_DNS=$(yq "$DNS_QUERY" instances.yaml)
+
+  echo "=========================================="
+  echo "Internal DNS: ${DNS}"
+  echo "Using external DNS: ${EXTERNAL_DNS}"
+  SSH_CMD="ssh -o StrictHostKeyChecking=no ubuntu@$EXTERNAL_DNS"
+
+  # Setting the sysctl properties
+  echo "Setting values"
+  $SSH_CMD 'sudo sysctl fs.inotify.max_user_watches=655360'
+  $SSH_CMD 'sudo sysctl fs.inotify.max_user_instances=1280'
+
+  # To check the settings
+  echo "Checking values"
+  check_sysctl $SSH_CMD "fs.inotify.max_user_watches" "65536"
+  check_sysctl $SSH_CMD "fs.inotify.max_user_instances" "1280"
+  echo "=========================================="
+done
+
+rm instances.yaml


### PR DESCRIPTION
Fixes #1210 

Investigation of the issue showed that trial pods for Katib consistently fail on EKS because of `metrics-logger-and-collector` container erroring out with the following message

```
(base) jovyan@workload-test-0:~$ kubectl logs -n 200 cmaes-example-4rm4bmt2-mkhrj -n admin -c metrics-logger-and-collector
I0224 12:38:04.158021      28 main.go:396] Trial Name: cmaes-example-4rm4bmt2
100.0%12:38:04.158578      28 main.go:139] 
100.6%12:38:04.160186      28 main.go:139] 
100.0%12:38:04.160318      28 main.go:139] 
119.3%12:38:04.160379      28 main.go:139] 
2025/02/24 12:38:04 FATAL -- failed to create Watcher
goroutine 6 [running]:
runtime/debug.Stack()
    /usr/local/go/src/runtime/debug/stack.go:24 +0x5e
github.com/hpcloud/tail/util.Fatal({0xdce7f6?, 0x411a3b?}, {0x0, 0x0, 0x0})
    /go/pkg/mod/github.com/hpcloud/tail@v1.0.1-0.20180514194441-a1dbeea552b7/util/util.go:22 +0x8b
github.com/hpcloud/tail/watch.(*InotifyTracker).run(0xc00004a140)
    /go/pkg/mod/github.com/hpcloud/tail@v1.0.1-0.20180514194441-a1dbeea552b7/watch/inotify_tracker.go:219 +0x65
created by github.com/hpcloud/tail/watch.init.func1 in goroutine 5
    /go/pkg/mod/github.com/hpcloud/tail@v1.0.1-0.20180514194441-a1dbeea552b7/watch/inotify_tracker.go:54 +0x14e
```

As mentioned [here](https://github.com/kubeflow/katib/issues/2434), this may be due to the `too many open files` exception. 

Indeed setting the sysctl properties 

```
sudo sysctl fs.inotify.max_user_instances=1280
sudo sysctl fs.inotify.max_user_watches=655360
```

on the EKS worker nodes seems to fix the issue (see [here](https://github.com/canonical/bundle-kubeflow/actions/runs/13504705058))

I have also checked that AKS does not seem to be affected by the same issue, see [here](https://github.com/canonical/bundle-kubeflow/actions/runs/13518298872/job/37771632988)