### PR TITLE
ci: remove compromised action tj-actions/changed-files

### DIFF
--- a/.github/workflows/release-bundle-to-charmhub.yaml
+++ b/.github/workflows/release-bundle-to-charmhub.yaml
@@ -18,22 +18,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get files changed
-        id: changed-files
-        uses: tj-actions/changed-files@v37
+# FIXME: Skip due to security vulnerability in https://github.com/tj-actions/changed-files/issues/2463
+      # - name: Get files changed
+      #   id: changed-files
+      #   uses: tj-actions/changed-files@v37
 
-      - name: Get releases affected
-        id: get-releases-affected
-        run: python scripts/get_releases_affected.py ${{ steps.changed-files.outputs.all_changed_files }}
+  #     - name: Get releases affected
+  #       id: get-releases-affected
+  #       run: python scripts/get_releases_affected.py ${{ steps.changed-files.outputs.all_changed_files }}
 
-  run-tests-and-publish-bundle-for-releases-affected:
-    name: Run bundle tests and publish to Charmhub
-    needs: [get-releases-affected]
-    strategy:
-      fail-fast: false
-      matrix:
-        release: ${{ fromJson(needs.get-releases-affected.outputs.releases_affected) }}
-    uses: ./.github/workflows/run-tests-and-publish-bundle.yaml
-    with:
-      release: ${{ matrix.release }}
-    secrets: inherit
+  # run-tests-and-publish-bundle-for-releases-affected:
+  #   name: Run bundle tests and publish to Charmhub
+  #   needs: [get-releases-affected]
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       release: ${{ fromJson(needs.get-releases-affected.outputs.releases_affected) }}
+  #   uses: ./.github/workflows/run-tests-and-publish-bundle.yaml
+  #   with:
+  #     release: ${{ matrix.release }}
+  #   secrets: inherit


### PR DESCRIPTION
Skips `tj-actions/changed-files` due to https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/