### PR TITLE
ci(chore): migrate GH runners to ubuntu 24.04

### DIFF
--- a/.github/workflows/delete-aws-volumes.yaml
+++ b/.github/workflows/delete-aws-volumes.yaml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   delete-volumes:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/get-images-and-scan.yaml
+++ b/.github/workflows/get-images-and-scan.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   get-images:
     name: Get images
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       images-array: ${{ steps.set-images-array.outputs.images-array }}
     steps:
@@ -47,7 +47,7 @@ jobs:
 
   scan-images-upload-individual-reports:
     name: Run vulnerability scans and upload reports
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: get-images
     outputs:
       release-track: ${{ steps.release-track.outputs.release-track }}
@@ -97,7 +97,7 @@ jobs:
 
   generate-and-upload-summary:
     name: Generate and upload summary of vulnerability reports
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: scan-images-upload-individual-reports
     # This always() is required as we always want to generate and upload summaries even
     # if the previous job had one or more failures.

--- a/.github/workflows/release-bundle-to-charmhub.yaml
+++ b/.github/workflows/release-bundle-to-charmhub.yaml
@@ -10,7 +10,7 @@ jobs:
 
   get-releases-affected:
     name: Get releases affected
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       releases_affected: ${{ steps.get-releases-affected.outputs.releases_affected_json }}
     steps:

--- a/.github/workflows/run-tests-and-publish-bundle.yaml
+++ b/.github/workflows/run-tests-and-publish-bundle.yaml
@@ -22,7 +22,7 @@ on:
 jobs:
   get-release-inputs:
     name: Get required inputs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       bundle_path: ${{ steps.bundle-path.outputs.bundle_path }}
       bundle_test_path: ${{ steps.bundle-test-path.outputs.bundle_test_path }}
@@ -50,7 +50,7 @@ jobs:
 
   publish-bundle-for-releases-affected:
     name: Publish bundle
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # we'll need to add back `run-tests` in the `needs` part, once we bring it back
     needs: [get-release-inputs]
     steps:


### PR DESCRIPTION
Closes #1230 
Note than in this repo, the runners were on 22.04 so it is not urgent that we migrate them for now, but it's to be consistent with other repos