### PR TITLE
tests: Replace github action with bash script

### DIFF
--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -57,12 +57,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Run YAML to Github Output Action
-        id: yaml-output
-        uses: christian-ci/action-yaml-github-output@v2
-        with:
-          file_path: ".github/dependencies.yaml"
-          main_key: ${{ matrix.bundle_version }}
+      - name: Set envvars from dependencies.yaml
+        run: |
+          if [[ $(yq eval ".\"${{ matrix.bundle_version }}\"" ".github/dependencies.yaml") == "null" ]]; 
+          then
+            echo "Bundle version '${{ matrix.bundle_version }}' not found in dependencies.yaml. Exiting."
+            exit 1
+          fi
+
+          yq eval ".\"${{ matrix.bundle_version }}\"" ".github/dependencies.yaml" | \
+            yq eval 'to_entries | .[] | "\(.key)=\(.value)"' - | while IFS= read -r line; do
+              echo "$line" >> "$GITHUB_ENV"
+          done
 
       - name: Update ENV variables from inputs if available
         run: |

--- a/.github/workflows/deploy-to-eks.yaml
+++ b/.github/workflows/deploy-to-eks.yaml
@@ -55,12 +55,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Run YAML to Github Output Action
-        id: yaml-output
-        uses: christian-ci/action-yaml-github-output@v2
-        with:
-          file_path: ".github/dependencies.yaml"
-          main_key: ${{ matrix.bundle_version }}
+      - name: Set envvars from dependencies.yaml
+        run: |
+          if [[ $(yq eval ".\"${{ matrix.bundle_version }}\"" ".github/dependencies.yaml") == "null" ]]; 
+          then
+            echo "Bundle version '${{ matrix.bundle_version }}' not found in dependencies.yaml. Exiting."
+            exit 1
+          fi
+
+          yq eval ".\"${{ matrix.bundle_version }}\"" ".github/dependencies.yaml" | \
+            yq eval 'to_entries | .[] | "\(.key)=\(.value)"' - | while IFS= read -r line; do
+              echo "$line" >> "$GITHUB_ENV"
+          done
 
       - name: Update ENV variables from inputs if available
         run: |


### PR DESCRIPTION
Replace github action with small bash script. This is to enhance
security since those workflows have access to credentials/repo's
secrets.

Example runs:
* AKS https://github.com/canonical/bundle-kubeflow/actions/runs/15445131023. AKS is expected to fail during cluster creation for 1.8 and 1.9 but envvars can be viewed in the steps.
* EKS https://github.com/canonical/bundle-kubeflow/actions/runs/15444359091/job/43469888979