### PR TITLE
fix: remove setting namespace config for `knative-{eventing, serving}` charms in `latest/edge`

### DIFF
--- a/.github/workflows/release-bundle.yaml
+++ b/.github/workflows/release-bundle.yaml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   release-bundle:
-    name: release bundle
+    name: releasea bundle
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Part of https://github.com/canonical/knative-operators/issues/348