### PR TITLE
chore: update latest/edge bundle.yaml to integrate metacontroller with ambient

### DIFF
--- a/releases/latest/edge/bundle.yaml
+++ b/releases/latest/edge/bundle.yaml
@@ -325,3 +325,4 @@ relations:
   - [istio-beacon-k8s:service-mesh, kubeflow-profiles:service-mesh]
   - [kfp-metadata-writer:grpc, mlmd:grpc]
   - [kubeflow-dashboard:kubeflow-profiles, kubeflow-profiles:kubeflow-profiles]
+  - [istio-beacon-k8s:service-mesh, metacontroller-operator:service-mesh]


### PR DESCRIPTION
Adds relation between `istio-beacon-k8s:service-mesh` and `metacontroller-operator:service-mesh` in `releases/latest/edge/bundle.yaml`, enabling service mesh integration for the metacontroller operator.